### PR TITLE
Update ignore patterns while composing packages

### DIFF
--- a/cmd/package.go
+++ b/cmd/package.go
@@ -283,8 +283,7 @@ func CollectPackage(repo *util.Repo, packageDir string, pullMissing bool, custom
 		}
 
 		relPath := strings.TrimPrefix(path, packageDir)
-		if relPath != "" && !strings.HasPrefix(relPath, "/meta") && !strings.HasPrefix(relPath, "/mpm-pkg") {
-
+		if !pathIgnored(relPath) {
 			switch {
 			case info.Mode()&os.ModeSymlink == os.ModeSymlink:
 				return os.Symlink(link, filepath.Join(targetPath, relPath))
@@ -345,6 +344,13 @@ func collectDirectoryContents(packageDir string) (map[string]string, error) {
 	})
 
 	return contents, err
+}
+
+func pathIgnored(path string) bool {
+	return path == "" ||
+		strings.HasPrefix(path, "/meta") ||
+		strings.HasPrefix(path, "/mpm-pkg") ||
+		strings.HasPrefix(path, "/.git")
 }
 
 func ImportPackage(repo *util.Repo, packageDir string) error {

--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -154,3 +154,25 @@ func (*suite) TestFileHashing(c *C) {
 		c.Assert(hostHash, Equals, hash)
 	}
 }
+
+func (*suite) TestPathIgnored(c *C) {
+	paths := map[string]bool{
+		"/meta":              true,
+		"/meta/package.yml":  true,
+		"/meta/":             true,
+		"/mpm-pkg":           true,
+		"/mpm-pkg/":          true,
+		"/mpm-pkg/file":      true,
+		"/.git":              true,
+		"/.git/":             true,
+		"/.git/subpath":      true,
+		"/met":               false,
+		"/mpm":               false,
+		"/.gi":               false,
+		"/long/path/to/file": false,
+	}
+
+	for path, ignored := range paths {
+		c.Assert(pathIgnored(path), Equals, ignored)
+	}
+}


### PR DESCRIPTION
This patch adds `.git` to the list of ignored prefixes while collecting
package content. Tests are also added making sure various paths are
properly handled.