### PR TITLE
Add support for QEMU vhost networking

### DIFF
--- a/capstan.go
+++ b/capstan.go
@@ -143,7 +143,7 @@ func main() {
 				cli.StringFlag{Name: "p", Value: hypervisor.Default(), Usage: "hypervisor: qemu|vbox|vmw|gce"},
 				cli.StringFlag{Name: "m", Value: "1G", Usage: "memory size"},
 				cli.IntFlag{Name: "c", Value: 2, Usage: "number of CPUs"},
-				cli.StringFlag{Name: "n", Value: "nat", Usage: "networking: nat|bridge|tap"},
+				cli.StringFlag{Name: "n", Value: "nat", Usage: "networking: nat|bridge|tap|vhost"},
 				cli.BoolFlag{Name: "v", Usage: "verbose mode"},
 				cli.StringFlag{Name: "b", Value: "", Usage: "networking device (bridge or tap): e.g., virbr0, vboxnet0, tap0"},
 				cli.StringSliceFlag{Name: "f", Value: new(cli.StringSlice), Usage: "port forwarding rules"},

--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -322,7 +322,15 @@ func (c *VMConfig) vmNetworking() ([]string, error) {
 		}
 		args = append(args, "-netdev", fmt.Sprintf("tap,id=hn0,ifname=%s,script=no,downscript=no", c.Bridge), "-device", fmt.Sprintf("virtio-net-pci,netdev=hn0,id=nic1,mac=%s", mac.String()))
 		return args, nil
+	case "vhost":
+		mac, err := c.vmMAC()
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, "-net", fmt.Sprintf("nic,model=virtio,macaddr=%s,netdev=nic-0", mac.String()), "-netdev", "tap,id=nic-0,vhost=on")
+		return args, nil
 	}
+
 	return nil, fmt.Errorf("%s: networking not supported", c.Networking)
 }
 


### PR DESCRIPTION
This patch enables support for running OSv instances with vhost enabled.
It relies on qemu scripts provided in `/etc` (e.g. `/etc/qemu-ifup`) to
bring tap device to qemu. Using vhost will make launched instances
accessible from the network.