### PR TITLE
Support .capstanignore file

### DIFF
--- a/Documentation/Capstanignore.md
+++ b/Documentation/Capstanignore.md
@@ -6,14 +6,14 @@ Capstan from uploading some subfolders (e.g. .idea/) and that's where `.capstani
 
 
 ## Ignored by default
-There are some files that are ignored (i.e. not copied to the unikernel that you're composing)
+There are some folders that are ignored (i.e. not copied to the unikernel that you're composing)
 even if you don't provide your own `.capstanignore` file:
 ```
-/meta/*
-/mpm-pkg/*
-/.git/*
+/meta
+/mpm-pkg
+/.git
 ```
-These files do not get uploaded to the unikernel even if they exist in your project folder. Go ahead,
+These folders do not get uploaded to the unikernel even if they exist in your project folder. Go ahead,
 verify by running:
 ```bash
 $ capstan config print
@@ -24,9 +24,9 @@ CAPSTAN_DISABLE_KVM: false
 
 --- curent directory configuration
 CAPSTANIGNORE:
-/meta/*
-/mpm-pkg/*
-/.git/*
+/meta
+/mpm-pkg
+/.git
 ```
 
 ## Specify your own .capstanignore
@@ -44,6 +44,9 @@ please find a valid `.capstanignore` file example showing the syntax:
 /**/myfile.txt
 
 # ignores folder 'myfolder' and all its content
+/myfolder
+
+# ignores all files and folders inside 'myfolder', but keeps the folder
 /myfolder/*
 
 # ignores any file with '.txt' suffix in project root directory
@@ -52,6 +55,9 @@ please find a valid `.capstanignore` file example showing the syntax:
 # ignores any file with '.txt' suffix in whole project (recursive)
 /**/*.txt
 
+# ignores any file that is inside any first-level directory (e.g. /result/file.txt),
+# but keeps the folders
+/*/*
 ```
 
 As you can see the syntax is that of .gitignore only you need to start each pattern with slash `/`. Note

--- a/Documentation/Capstanignore.md
+++ b/Documentation/Capstanignore.md
@@ -1,0 +1,71 @@
+# .capstanignore
+
+When composing a unikernel Capstan uploads **all** files from current directory to the unikernel. For
+simple demo applications this is totally acceptable, but sooner or later you'll want to prevent
+Capstan from uploading some subfolders (e.g. .idea/) and that's where `.capstanignore` comes in.
+
+
+## Ignored by default
+There are some files that are ignored (i.e. not copied to the unikernel that you're composing)
+even if you don't provide your own `.capstanignore` file:
+```
+/meta/*
+/mpm-pkg/*
+/.git/*
+```
+These files do not get uploaded to the unikernel even if they exist in your project folder. Go ahead,
+verify by running:
+```bash
+$ capstan config print
+--- global configuration
+CAPSTAN_ROOT: /home/miha/.capstan
+CAPSTAN_REPO_URL: https://mikelangelo-capstan.s3.amazonaws.com/
+CAPSTAN_DISABLE_KVM: false
+
+--- curent directory configuration
+CAPSTANIGNORE:
+/meta/*
+/mpm-pkg/*
+/.git/*
+```
+
+## Specify your own .capstanignore
+Go ahead, create a new file in your project root directory and name it `.capstanignore`. Below
+please find a valid `.capstanignore` file example showing the syntax:
+
+```
+# ignores file 'myfile.txt' in project root directory
+/myfile.txt
+
+# ignores file 'myfile.txt' in '/myfolder' directory
+/myfolder/myfile.txt
+
+# ignores any file 'myfile.txt' in whole project (recursive)
+/**/myfile.txt
+
+# ignores folder 'myfolder' and all its content
+/myfolder/*
+
+# ignores any file with '.txt' suffix in project root directory
+/*.txt
+
+# ignores any file with '.txt' suffix in whole project (recursive)
+/**/*.txt
+
+```
+
+As you can see the syntax is that of .gitignore only you need to start each pattern with slash `/`. Note
+that negation (`!`) is not supported. You can see what files are actually getting excluded in your
+case by using `--verbose` flag:
+```bash
+$ capstan package collect --verbose
+Resolved runtime into: node
+Prepending 'node' runtime dependencies to dep list: [eu.mikelangelo-project.app.node-4.4.5]
+.capstanignore: ignore /bin
+.capstanignore: ignore /bin/osv-launch-services.sh
+.capstanignore: ignore /bin/osv-launch-worker.sh
+.capstanignore: ignore /bin/upload_batch.sh
+.capstanignore: ignore /doc
+.capstanignore: ignore /doc/setup-phase.png
+.capstanignore: ignore /doc/worker-phase.png
+```

--- a/capstan.go
+++ b/capstan.go
@@ -453,6 +453,7 @@ func main() {
 					Flags: []cli.Flag{
 						cli.BoolFlag{Name: "pull-missing, p", Usage: "attempt to pull packages missing from a local repository"},
 						cli.StringFlag{Name: "boot", Usage: "specify config_set name to boot unikernel with"},
+						cli.BoolFlag{Name: "verbose, v", Usage: "verbose mode"},
 					},
 					Action: func(c *cli.Context) error {
 						repo := util.NewRepo(c.GlobalString("u"))
@@ -460,7 +461,7 @@ func main() {
 
 						pullMissing := c.Bool("pull-missing")
 
-						if err := cmd.CollectPackage(repo, packageDir, pullMissing, c.String("boot")); err != nil {
+						if err := cmd.CollectPackage(repo, packageDir, pullMissing, c.String("boot"), c.Bool("verbose")); err != nil {
 							return cli.NewExitError(err.Error(), EX_DATAERR)
 						}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -8,12 +8,24 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/mikelangelo-project/capstan/core"
 	"github.com/mikelangelo-project/capstan/util"
 	"github.com/urfave/cli"
 )
 
 // ConfigPrint prints current capstan configuration to console.
-func ConfigPrint(c *cli.Context) {
+func ConfigPrint(c *cli.Context) error {
 	repo := util.NewRepo(c.GlobalString("u"))
+	fmt.Println("--- global configuration")
 	repo.PrintRepo()
+	fmt.Println()
+
+	fmt.Println("--- curent directory configuration")
+	fmt.Println("CAPSTANIGNORE:")
+	capstanignore := core.CapstanignoreInit("./.capstanignore", true)
+	capstanignore.PrintPatterns()
+
+	return nil
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -9,6 +9,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/mikelangelo-project/capstan/core"
 	"github.com/mikelangelo-project/capstan/util"
@@ -24,8 +25,16 @@ func ConfigPrint(c *cli.Context) error {
 
 	fmt.Println("--- curent directory configuration")
 	fmt.Println("CAPSTANIGNORE:")
-	capstanignore := core.CapstanignoreInit("./.capstanignore")
-	capstanignore.PrintPatterns()
+	// Read .capstanignore if exists.
+	capstanignorePath := "./.capstanignore"
+	if _, err := os.Stat(capstanignorePath); os.IsNotExist(err) {
+		capstanignorePath = ""
+	}
+	if capstanignore, err := core.CapstanignoreInit(capstanignorePath); err == nil {
+		capstanignore.PrintPatterns()
+	} else {
+		fmt.Println(err)
+	}
 
 	return nil
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -24,7 +24,7 @@ func ConfigPrint(c *cli.Context) error {
 
 	fmt.Println("--- curent directory configuration")
 	fmt.Println("CAPSTANIGNORE:")
-	capstanignore := core.CapstanignoreInit("./.capstanignore", true)
+	capstanignore := core.CapstanignoreInit("./.capstanignore")
 	capstanignore.PrintPatterns()
 
 	return nil

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -274,13 +274,16 @@ func CollectPackage(repo *util.Repo, packageDir string, pullMissing bool, custom
 
 	// Read .capstanignore if exists.
 	capstanignorePath := filepath.Join(packageDir, ".capstanignore")
-	if _, err = os.Stat(capstanignorePath); os.IsNotExist(err) {
+	if _, err := os.Stat(capstanignorePath); os.IsNotExist(err) {
 		if verbose {
 			fmt.Println("WARN: .capstanignore not found, all files will be uploaded")
 		}
 		capstanignorePath = ""
 	}
-	capstanignore := core.CapstanignoreInit(capstanignorePath)
+	capstanignore, err := core.CapstanignoreInit(capstanignorePath)
+	if err != nil {
+		return err
+	}
 
 	// Now we need to append the content of the current package into the target directory.
 	// This should override any file from the required packages.

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -311,21 +311,20 @@ func CollectPackage(repo *util.Repo, packageDir string, pullMissing bool, custom
 			if err := persistBootCmdsIntoFiles(data, targetPath, customBoot, ""); err != nil {
 				return err
 			}
+			return nil
 		}
 
 		// Ignore what needs to be ignored.
 		if capstanignore.IsIgnored(relPath) {
 			if verbose {
-				display := true
-				for _, pattern := range core.CAPSTANIGNORE_ALWAYS {
-					if strings.HasPrefix(relPath, strings.Replace(pattern, "/*", "", 1)) {
-						display = false
-						break
-					}
+				suffix := ""
+				if info.IsDir() {
+					suffix = " (entire folder)"
 				}
-				if display {
-					fmt.Println(".capstanignore: ignore", relPath)
-				}
+				fmt.Printf(".capstanignore: ignore %s%s\n", relPath, suffix)
+			}
+			if info.IsDir() {
+				return filepath.SkipDir
 			}
 			return nil
 		}

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -272,7 +272,15 @@ func CollectPackage(repo *util.Repo, packageDir string, pullMissing bool, custom
 		}
 	}
 
-	capstanignore := core.CapstanignoreInit(filepath.Join(packageDir, ".capstanignore"), verbose)
+	// Read .capstanignore if exists.
+	capstanignorePath := filepath.Join(packageDir, ".capstanignore")
+	if _, err = os.Stat(capstanignorePath); os.IsNotExist(err) {
+		if verbose {
+			fmt.Println("WARN: .capstanignore not found, all files will be uploaded")
+		}
+		capstanignorePath = ""
+	}
+	capstanignore := core.CapstanignoreInit(capstanignorePath)
 
 	// Now we need to append the content of the current package into the target directory.
 	// This should override any file from the required packages.

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -160,7 +160,7 @@ func ComposePackage(repo *util.Repo, imageSize int64, updatePackage bool, verbos
 	commandLine = constructBootCmdFromArguments(commandLine, customBoot, packageDir)
 
 	// First, collect the contents of the package.
-	if err := CollectPackage(repo, packageDir, pullMissing, customBoot); err != nil {
+	if err := CollectPackage(repo, packageDir, pullMissing, customBoot, verbose); err != nil {
 		return err
 	}
 
@@ -216,7 +216,7 @@ func ComposePackage(repo *util.Repo, imageSize int64, updatePackage bool, verbos
 
 // CollectPackage will try to resolve all of the dependencies of the given package
 // and collect the content in the $CWD/mpm-pkg directory.
-func CollectPackage(repo *util.Repo, packageDir string, pullMissing bool, customBoot string) error {
+func CollectPackage(repo *util.Repo, packageDir string, pullMissing bool, customBoot string, verbose bool) error {
 	// Get the manifest file of the given package.
 	pkg, err := core.ParsePackageManifest(filepath.Join(packageDir, "meta", "package.yaml"))
 	if err != nil {
@@ -272,6 +272,8 @@ func CollectPackage(repo *util.Repo, packageDir string, pullMissing bool, custom
 		}
 	}
 
+	capstanignore := core.CapstanignoreInit(filepath.Join(packageDir, ".capstanignore"), verbose)
+
 	// Now we need to append the content of the current package into the target directory.
 	// This should override any file from the required packages.
 	err = filepath.Walk(packageDir, func(path string, info os.FileInfo, err error) error {
@@ -290,22 +292,9 @@ func CollectPackage(repo *util.Repo, packageDir string, pullMissing bool, custom
 		}
 
 		relPath := strings.TrimPrefix(path, packageDir)
-		if !pathIgnored(relPath) {
-			switch {
-			case info.Mode()&os.ModeSymlink == os.ModeSymlink:
-				return os.Symlink(link, filepath.Join(targetPath, relPath))
 
-			case info.IsDir():
-				return os.MkdirAll(filepath.Join(targetPath, relPath), info.Mode())
-
-			case info.Mode().IsRegular():
-				return util.CopyLocalFile(filepath.Join(targetPath, relPath), path)
-
-			default:
-				return fmt.Errorf("File %s has unsupported mode %v", path, info.Mode())
-			}
-
-		} else if relPath == "/meta/run.yaml" {
+		// Apply meta/run.yaml before ignoring it.
+		if relPath == "/meta/run.yaml" {
 			// Prepare files with boot commands.
 			data, err := ioutil.ReadFile(path)
 			if err != nil {
@@ -316,7 +305,36 @@ func CollectPackage(repo *util.Repo, packageDir string, pullMissing bool, custom
 			}
 		}
 
-		return nil
+		// Ignore what needs to be ignored.
+		if capstanignore.IsIgnored(relPath) {
+			if verbose {
+				display := true
+				for _, pattern := range core.CAPSTANIGNORE_ALWAYS {
+					if strings.HasPrefix(relPath, strings.Replace(pattern, "/*", "", 1)) {
+						display = false
+						break
+					}
+				}
+				if display {
+					fmt.Println(".capstanignore: ignore", relPath)
+				}
+			}
+			return nil
+		}
+
+		switch {
+		case info.Mode()&os.ModeSymlink == os.ModeSymlink:
+			return os.Symlink(link, filepath.Join(targetPath, relPath))
+
+		case info.IsDir():
+			return os.MkdirAll(filepath.Join(targetPath, relPath), info.Mode())
+
+		case info.Mode().IsRegular():
+			return util.CopyLocalFile(filepath.Join(targetPath, relPath), path)
+
+		default:
+			return fmt.Errorf("File %s has unsupported mode %v", path, info.Mode())
+		}
 	})
 
 	if err != nil {
@@ -351,13 +369,6 @@ func collectDirectoryContents(packageDir string) (map[string]string, error) {
 	})
 
 	return contents, err
-}
-
-func pathIgnored(path string) bool {
-	return path == "" ||
-		strings.HasPrefix(path, "/meta") ||
-		strings.HasPrefix(path, "/mpm-pkg") ||
-		strings.HasPrefix(path, "/.git")
 }
 
 func ImportPackage(repo *util.Repo, packageDir string) error {

--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -8,13 +8,14 @@
 package cmd
 
 import (
-	"github.com/mikelangelo-project/capstan/core"
-	"github.com/mikelangelo-project/capstan/util"
-	. "gopkg.in/check.v1"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/mikelangelo-project/capstan/core"
+	"github.com/mikelangelo-project/capstan/util"
+	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -159,27 +160,5 @@ func (*suite) TestFileHashing(c *C) {
 		c.Assert(err, IsNil)
 
 		c.Assert(hostHash, Equals, hash)
-	}
-}
-
-func (*suite) TestPathIgnored(c *C) {
-	paths := map[string]bool{
-		"/meta":              true,
-		"/meta/package.yml":  true,
-		"/meta/":             true,
-		"/mpm-pkg":           true,
-		"/mpm-pkg/":          true,
-		"/mpm-pkg/file":      true,
-		"/.git":              true,
-		"/.git/":             true,
-		"/.git/subpath":      true,
-		"/met":               false,
-		"/mpm":               false,
-		"/.gi":               false,
-		"/long/path/to/file": false,
-	}
-
-	for path, ignored := range paths {
-		c.Assert(pathIgnored(path), Equals, ignored)
 	}
 }

--- a/core/capstanignore.go
+++ b/core/capstanignore.go
@@ -85,14 +85,6 @@ func (c *capstanignore) AddPattern(pattern string) error {
 		return err
 	}
 
-	// also ignore folder when all its content is ignored
-	for strings.HasSuffix(pattern, "/*") {
-		pattern = strings.TrimSuffix(pattern, "/*")
-		safePattern = transformCapstanignoreToRegex(pattern)
-		compiled := regexp.MustCompile(safePattern)
-		c.ignoredC = append(c.ignoredC, compiled)
-	}
-
 	return nil
 }
 

--- a/core/capstanignore.go
+++ b/core/capstanignore.go
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2017 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package core
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+type Capstanignore interface {
+	LoadFile(path string) error
+	AddPattern(pattern string) error
+	PrintPatterns()
+	IsIgnored(path string) bool
+}
+
+var CAPSTANIGNORE_ALWAYS []string = []string{"/meta/*", "/mpm-pkg/*", "/.git/*"}
+
+// CapstanignoreInit creates a new capstanignore struct that is
+// used when deciding whether a file should be included in unikernel
+// or not. You can provide `path` to the .capstanignore file to load
+// it or pass empty string "" if you have none. Note that once having
+// capstanignore struct you can load as many files as you want (using
+// .LoadFile function) or manually add as many patterns as you like
+// (using .AddPattern function).
+func CapstanignoreInit(path string, verbose bool) Capstanignore {
+	c := capstanignore{verbose: verbose}
+
+	// Load capstanignore file if path was given.
+	if path != "" {
+		if err := c.LoadFile(path); verbose && err != nil {
+			fmt.Println("WARN: failed to load .capstanignore file:", err)
+		}
+	}
+
+	// Always ignore some common paths.
+	for _, pattern := range CAPSTANIGNORE_ALWAYS {
+		c.AddPattern(pattern)
+	}
+	return &c
+}
+
+type capstanignore struct {
+	ignored  []string         // list of all ignored patterns
+	ignoredC []*regexp.Regexp // list of compiled patterns
+	verbose  bool
+}
+
+// LoadFile attempts to parse .capstanignore file on given path.
+// If success, it remembers all patterns and closes file.
+func (c *capstanignore) LoadFile(path string) error {
+	if file, err := os.Open(path); err == nil {
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			line := strings.Trim(scanner.Text(), " ")
+			if len(line) == 0 || strings.HasPrefix(line, "#") {
+				continue
+			}
+			if errPattern := c.AddPattern(line); errPattern != nil {
+				return errPattern
+			}
+		}
+	}
+	return nil
+}
+
+// AddPattern adds a pattern to be ignored.
+func (c *capstanignore) AddPattern(pattern string) error {
+	safePattern := transformCapstanignoreToRegex(pattern)
+	if compiled, err := regexp.Compile(safePattern); err == nil {
+		c.ignored = append(c.ignored, pattern)
+		c.ignoredC = append(c.ignoredC, compiled)
+	} else {
+		return err
+	}
+
+	// also ignore folder when all its content is ignored
+	for strings.HasSuffix(pattern, "/*") {
+		pattern = strings.TrimSuffix(pattern, "/*")
+		safePattern = transformCapstanignoreToRegex(pattern)
+		compiled := regexp.MustCompile(safePattern)
+		c.ignoredC = append(c.ignoredC, compiled)
+	}
+
+	return nil
+}
+
+func (c *capstanignore) IsIgnored(path string) bool {
+	for _, pattern := range c.ignoredC {
+		if pattern.MatchString(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *capstanignore) PrintPatterns() {
+	for _, pattern := range c.ignored {
+		fmt.Println(pattern)
+	}
+}
+
+// transformCapstanignoreToRegex transforms capstanignore synstax to regex systax.
+func transformCapstanignoreToRegex(pattern string) string {
+	// preprocess
+	pattern = strings.Replace(pattern, "/**/", "{two-stars}", -1)
+	if strings.HasSuffix(pattern, "/*") {
+		pattern = strings.TrimSuffix(pattern, "/*")
+		pattern = pattern + "{all-beneath}"
+	}
+
+	// Implicit ^ at the beginning
+	if !strings.HasPrefix(pattern, "^") {
+		pattern = "^" + pattern
+	}
+	// Star * means only one folder level
+	pattern = strings.Replace(pattern, "*", "[^/]*", -1)
+	// Dot . means actual dot
+	pattern = strings.Replace(pattern, ".", "\\.", -1)
+	// Two stars between two slashes /**/ mean all folder levels
+	pattern = strings.Replace(pattern, "{two-stars}", ".*", -1)
+	// /* at the end means also all subfolders
+	pattern = strings.Replace(pattern, "{all-beneath}", "/.*", 1)
+	// Implicit $ at the end
+	if !strings.HasSuffix(pattern, "$") {
+		pattern = pattern + "$"
+	}
+
+	return pattern
+}

--- a/core/capstanignore.go
+++ b/core/capstanignore.go
@@ -22,7 +22,7 @@ type Capstanignore interface {
 	IsIgnored(path string) bool
 }
 
-var CAPSTANIGNORE_ALWAYS []string = []string{"/meta/*", "/mpm-pkg/*", "/.git/*"}
+var CAPSTANIGNORE_ALWAYS []string = []string{"/meta", "/mpm-pkg", "/.git"}
 
 // CapstanignoreInit creates a new capstanignore struct that is
 // used when deciding whether a file should be included in unikernel
@@ -96,6 +96,11 @@ func (c *capstanignore) AddPattern(pattern string) error {
 	return nil
 }
 
+// IsIgnored returns true if path given is on ignore list.
+// But notice that if a folder is ignored, it is up to caller
+// to ignore all files beneath as well. E.g. if pattern `/myfolder`
+// is used, then IsIgnored will return false for all subfolders and
+// files inside the `/myfolder` directory.
 func (c *capstanignore) IsIgnored(path string) bool {
 	for _, pattern := range c.ignoredC {
 		if pattern.MatchString(path) {

--- a/core/capstanignore.go
+++ b/core/capstanignore.go
@@ -37,7 +37,7 @@ func CapstanignoreInit(path string) (Capstanignore, error) {
 	// Load capstanignore file if path was given.
 	if path != "" {
 		if err := c.LoadFile(path); err != nil {
-			return nil, fmt.Errorf("failed to parse .capstanfile: %s\n", err)
+			return nil, fmt.Errorf("failed to parse .capstanignore: %s\n", err)
 		}
 	}
 

--- a/core/capstanignore.go
+++ b/core/capstanignore.go
@@ -31,12 +31,12 @@ var CAPSTANIGNORE_ALWAYS []string = []string{"/meta/*", "/mpm-pkg/*", "/.git/*"}
 // capstanignore struct you can load as many files as you want (using
 // .LoadFile function) or manually add as many patterns as you like
 // (using .AddPattern function).
-func CapstanignoreInit(path string, verbose bool) Capstanignore {
-	c := capstanignore{verbose: verbose}
+func CapstanignoreInit(path string) Capstanignore {
+	c := capstanignore{}
 
 	// Load capstanignore file if path was given.
 	if path != "" {
-		if err := c.LoadFile(path); verbose && err != nil {
+		if err := c.LoadFile(path); err != nil {
 			fmt.Println("WARN: failed to load .capstanignore file:", err)
 		}
 	}
@@ -51,7 +51,6 @@ func CapstanignoreInit(path string, verbose bool) Capstanignore {
 type capstanignore struct {
 	ignored  []string         // list of all ignored patterns
 	ignoredC []*regexp.Regexp // list of compiled patterns
-	verbose  bool
 }
 
 // LoadFile attempts to parse .capstanignore file on given path.
@@ -70,6 +69,8 @@ func (c *capstanignore) LoadFile(path string) error {
 				return errPattern
 			}
 		}
+	} else {
+		return err
 	}
 	return nil
 }

--- a/core/capstanignore.go
+++ b/core/capstanignore.go
@@ -31,13 +31,13 @@ var CAPSTANIGNORE_ALWAYS []string = []string{"/meta", "/mpm-pkg", "/.git"}
 // capstanignore struct you can load as many files as you want (using
 // .LoadFile function) or manually add as many patterns as you like
 // (using .AddPattern function).
-func CapstanignoreInit(path string) Capstanignore {
+func CapstanignoreInit(path string) (Capstanignore, error) {
 	c := capstanignore{}
 
 	// Load capstanignore file if path was given.
 	if path != "" {
 		if err := c.LoadFile(path); err != nil {
-			fmt.Println("WARN: failed to load .capstanignore file:", err)
+			return nil, fmt.Errorf("failed to parse .capstanfile: %s\n", err)
 		}
 	}
 
@@ -45,7 +45,7 @@ func CapstanignoreInit(path string) Capstanignore {
 	for _, pattern := range CAPSTANIGNORE_ALWAYS {
 		c.AddPattern(pattern)
 	}
-	return &c
+	return &c, nil
 }
 
 type capstanignore struct {

--- a/test/core/capstanignore_test.go
+++ b/test/core/capstanignore_test.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2017 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package core_test
+
+import (
+	"testing"
+
+	"github.com/mikelangelo-project/capstan/core"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type testingCapstanignoreSuite struct{}
+
+var _ = Suite(&testingCapstanignoreSuite{})
+
+func (s *testingCapstanignoreSuite) TestIsIgnored(c *C) {
+	m := []struct {
+		comment      string
+		pattern      string
+		path         string
+		shouldIgnore bool
+	}{
+		{
+			"fully specified file in root #1",
+			"/myfile.txt", "/myfile.txt", true,
+		},
+		{
+			"fully specified file in root #2",
+			"/myfile.txt", "/myfolder/myfile.txt", false,
+		},
+
+		{
+			"fully specified file not in root #1",
+			"/myfolder/myfile.txt", "/myfile.txt", false,
+		},
+		{
+			"fully specified file not in root #2",
+			"/myfolder/myfile.txt", "/myfolder/myfile.txt", true,
+		},
+		{
+			"file by extension in root #1",
+			"/*.txt", "/myfile.txt", true,
+		},
+		{
+			"file by extension in root #2",
+			"/*.txt", "/myfolder/myfile.txt", false,
+		},
+		{
+			"file by extension not in root #1",
+			"/myfolder/*.txt", "/myfile.txt", false,
+		},
+		{
+			"file by extension not in root #2",
+			"/myfolder/*.txt", "/myfolder/myfile.txt", true,
+		},
+		{
+			"file by extension not in root #3",
+			"/myfolder/*.txt", "/myfolder/subfolder/myfile.txt", false,
+		},
+		{
+			"fully specified file in any subfolder #1",
+			"/**/file.txt", "/myfile.txt", true,
+		},
+		{
+			"fully specified file in any subfolder #2",
+			"/**/file.txt", "/myfolder/myfile.txt", true,
+		},
+		{
+			"fully specified file in any subfolder #3",
+			"/**/file.txt", "/myfolder/subfolder/myfile.txt", true,
+		},
+		{
+			"whole folder one level #1",
+			"/myfolder/*", "/myfolder/myfile.txt", true,
+		},
+		{
+			"whole folder one level #2",
+			"/myfolder/*", "/myfolder", true,
+		},
+		{
+			"whole folder one level #3",
+			"/myfolder/*", "/myfolder/subfolder/myfile.txt", true,
+		},
+		{
+			"whole folder one level #4",
+			"/myfolder/*", "/myfolder/subfolder", true,
+		},
+		{
+			"whole folder two levels #1",
+			"/myfolder/subfolder/*", "/myfolder/subfolder", true,
+		},
+		{
+			"whole folder two levels #2",
+			"/myfolder/subfolder/*", "/myfolder", false,
+		},
+		{
+			"whole folder two whole levels #1",
+			"/myfolder/*/*", "/myfolder", true,
+		},
+		{
+			"whole folder two whole levels #2",
+			"/myfolder/*/*", "/myfolder/subfolder", true,
+		},
+		{
+			"whole folder two whole levels #3",
+			"/myfolder/*/*", "/myfolder/subfolder/myfile.txt", true,
+		},
+		{
+			"any text file in project #1",
+			"/**/*.txt", "/myfile.txt", true,
+		},
+		{
+			"any text file in project #2",
+			"/**/*.txt", "/myfolder/myfile.txt", true,
+		},
+		{
+			"any text file in project #3",
+			"/**/*.txt", "/myfolder/subfolder/myfile.txt", true,
+		},
+		{
+			"additional test #1",
+			"/subfolder/*", "/myfolder/subfolder/myfile.txt", false,
+		},
+		{
+			"additional test #2",
+			"/myfolder/*.txt", "/myfolder/myfileXtxt", false,
+		},
+		{
+			"additional test #3",
+			"/myfolder", "/myfolder2", false,
+		},
+		{
+			"additional test #4",
+			"/myfolder/*", "/myfolder2", false,
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Setup
+		capstanignore := core.CapstanignoreInit("", false)
+		capstanignore.AddPattern(args.pattern)
+
+		// This is what we're testing here.
+		ignoreYesNo := capstanignore.IsIgnored(args.path)
+
+		// Expectations.
+		c.Check(ignoreYesNo, Equals, args.shouldIgnore)
+	}
+}

--- a/test/core/capstanignore_test.go
+++ b/test/core/capstanignore_test.go
@@ -155,3 +155,26 @@ func (s *testingCapstanignoreSuite) TestIsIgnored(c *C) {
 		c.Check(ignoreYesNo, Equals, args.shouldIgnore)
 	}
 }
+
+func (s *testingCapstanignoreSuite) TestIsIgnoredAlways(c *C) {
+	paths := map[string]bool{
+		"/meta":              true,
+		"/meta/package.yml":  true,
+		"/meta/":             true,
+		"/mpm-pkg":           true,
+		"/mpm-pkg/":          true,
+		"/mpm-pkg/file":      true,
+		"/.git":              true,
+		"/.git/":             true,
+		"/.git/subpath":      true,
+		"/met":               false,
+		"/mpm":               false,
+		"/.gi":               false,
+		"/long/path/to/file": false,
+	}
+
+	for path, ignored := range paths {
+		capstanignore := core.CapstanignoreInit("", false)
+		c.Assert(capstanignore.IsIgnored(path), Equals, ignored)
+	}
+}

--- a/test/core/capstanignore_test.go
+++ b/test/core/capstanignore_test.go
@@ -140,6 +140,18 @@ func (s *testingCapstanignoreSuite) TestIsIgnored(c *C) {
 			"additional test #4",
 			"/myfolder/*", "/myfolder2", false,
 		},
+		{
+			"always ignore /meta",
+			"", "/meta", true,
+		},
+		{
+			"always ignore /mpm-pkg",
+			"", "/mpm-pkg", true,
+		},
+		{
+			"always ignore /.git",
+			"", "/.git", true,
+		},
 	}
 	for i, args := range m {
 		c.Logf("CASE #%d: %s", i, args.comment)
@@ -153,28 +165,5 @@ func (s *testingCapstanignoreSuite) TestIsIgnored(c *C) {
 
 		// Expectations.
 		c.Check(ignoreYesNo, Equals, args.shouldIgnore)
-	}
-}
-
-func (s *testingCapstanignoreSuite) TestIsIgnoredAlways(c *C) {
-	paths := map[string]bool{
-		"/meta":              true,
-		"/meta/package.yml":  true,
-		"/meta/":             true,
-		"/mpm-pkg":           true,
-		"/mpm-pkg/":          true,
-		"/mpm-pkg/file":      true,
-		"/.git":              true,
-		"/.git/":             true,
-		"/.git/subpath":      true,
-		"/met":               false,
-		"/mpm":               false,
-		"/.gi":               false,
-		"/long/path/to/file": false,
-	}
-
-	for path, ignored := range paths {
-		capstanignore := core.CapstanignoreInit("")
-		c.Assert(capstanignore.IsIgnored(path), Equals, ignored)
 	}
 }

--- a/test/core/capstanignore_test.go
+++ b/test/core/capstanignore_test.go
@@ -145,7 +145,7 @@ func (s *testingCapstanignoreSuite) TestIsIgnored(c *C) {
 		c.Logf("CASE #%d: %s", i, args.comment)
 
 		// Setup
-		capstanignore := core.CapstanignoreInit("", false)
+		capstanignore := core.CapstanignoreInit("")
 		capstanignore.AddPattern(args.pattern)
 
 		// This is what we're testing here.
@@ -174,7 +174,7 @@ func (s *testingCapstanignoreSuite) TestIsIgnoredAlways(c *C) {
 	}
 
 	for path, ignored := range paths {
-		capstanignore := core.CapstanignoreInit("", false)
+		capstanignore := core.CapstanignoreInit("")
 		c.Assert(capstanignore.IsIgnored(path), Equals, ignored)
 	}
 }

--- a/test/core/capstanignore_test.go
+++ b/test/core/capstanignore_test.go
@@ -157,7 +157,7 @@ func (s *testingCapstanignoreSuite) TestIsIgnored(c *C) {
 		c.Logf("CASE #%d: %s", i, args.comment)
 
 		// Setup
-		capstanignore := core.CapstanignoreInit("")
+		capstanignore, _ := core.CapstanignoreInit("")
 		capstanignore.AddPattern(args.pattern)
 
 		// This is what we're testing here.

--- a/test/core/capstanignore_test.go
+++ b/test/core/capstanignore_test.go
@@ -82,7 +82,7 @@ func (s *testingCapstanignoreSuite) TestIsIgnored(c *C) {
 		},
 		{
 			"whole folder one level #2",
-			"/myfolder/*", "/myfolder", true,
+			"/myfolder/*", "/myfolder", false,
 		},
 		{
 			"whole folder one level #3",
@@ -94,7 +94,7 @@ func (s *testingCapstanignoreSuite) TestIsIgnored(c *C) {
 		},
 		{
 			"whole folder two levels #1",
-			"/myfolder/subfolder/*", "/myfolder/subfolder", true,
+			"/myfolder/subfolder/*", "/myfolder/subfolder", false,
 		},
 		{
 			"whole folder two levels #2",
@@ -102,11 +102,11 @@ func (s *testingCapstanignoreSuite) TestIsIgnored(c *C) {
 		},
 		{
 			"whole folder two whole levels #1",
-			"/myfolder/*/*", "/myfolder", true,
+			"/myfolder/*/*", "/myfolder", false,
 		},
 		{
 			"whole folder two whole levels #2",
-			"/myfolder/*/*", "/myfolder/subfolder", true,
+			"/myfolder/*/*", "/myfolder/subfolder", false,
 		},
 		{
 			"whole folder two whole levels #3",


### PR DESCRIPTION
It is now possible to use $PROJECT_PATH/.capstanignore file to exclude some files/folders from being uploaded to unikernel. User documentation for writing .capstanignore is provided.
