### PR TITLE
Function `repo.PrintRepo` is unable to raise error

### DIFF
--- a/capstan.go
+++ b/capstan.go
@@ -55,9 +55,7 @@ func main() {
 					Name:  "print",
 					Usage: "print current capstan configuration",
 					Action: func(c *cli.Context) error {
-						if err := cmd.ConfigPrint(c); err != nil {
-							return cli.NewExitError(err.Error(), EX_DATAERR)
-						}
+						cmd.ConfigPrint(c)
 						return nil
 					},
 				},

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ConfigPrint prints current capstan configuration to console.
-func ConfigPrint(c *cli.Context) error {
+func ConfigPrint(c *cli.Context) {
 	repo := util.NewRepo(c.GlobalString("u"))
-	return repo.PrintRepo()
+	repo.PrintRepo()
 }

--- a/util/repository.go
+++ b/util/repository.go
@@ -11,9 +11,6 @@ package util
 import (
 	"errors"
 	"fmt"
-	"github.com/mikelangelo-project/capstan/core"
-	"github.com/mikelangelo-project/capstan/image"
-	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"os"
@@ -22,6 +19,10 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/mikelangelo-project/capstan/core"
+	"github.com/mikelangelo-project/capstan/image"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -94,11 +95,10 @@ type ImageInfo struct {
 	Build         string
 }
 
-func (r *Repo) PrintRepo() error {
+func (r *Repo) PrintRepo() {
 	fmt.Printf("CAPSTAN_ROOT: %s\n", r.Path)
 	fmt.Printf("CAPSTAN_REPO_URL: %s\n", r.URL)
 	fmt.Printf("CAPSTAN_DISABLE_KVM: %v\n", r.DisableKvm)
-	return nil
 }
 
 func (r *Repo) ImportImage(imageName string, file string, version string, created string, description string, build string) error {


### PR DESCRIPTION
Since `repo.PrintRepo` can never return error, we drop error from its return list. The new function now returns nothing.