### PR TITLE
Allow Capstan to use meta/run.yaml before ignoring it

### DIFF
--- a/cmd/package.go
+++ b/cmd/package.go
@@ -315,6 +315,8 @@ func CollectPackage(repo *util.Repo, packageDir string, pullMissing bool, custom
 				return err
 			}
 			return nil
+		} else if relPath == "/meta" { // Prevent empty `/meta` dir from being uploaded.
+			return nil
 		}
 
 		// Ignore what needs to be ignored.

--- a/core/capstanignore.go
+++ b/core/capstanignore.go
@@ -22,7 +22,7 @@ type Capstanignore interface {
 	IsIgnored(path string) bool
 }
 
-var CAPSTANIGNORE_ALWAYS []string = []string{"/meta", "/mpm-pkg", "/.git"}
+var CAPSTANIGNORE_ALWAYS []string = []string{"/meta/*", "/mpm-pkg", "/.git"}
 
 // CapstanignoreInit creates a new Capstanignore struct that is
 // used when deciding whether a file should be included in unikernel

--- a/test/core/capstanignore_test.go
+++ b/test/core/capstanignore_test.go
@@ -141,8 +141,8 @@ func (s *testingCapstanignoreSuite) TestIsIgnored(c *C) {
 			"/myfolder/*", "/myfolder2", false,
 		},
 		{
-			"always ignore /meta",
-			"", "/meta", true,
+			"always ignore /meta/*",
+			"", "/meta/package.yaml", true,
 		},
 		{
 			"always ignore /mpm-pkg",


### PR DESCRIPTION
Having
```
/meta
```
specified as part of built-in capstanignore causes meta folder from not being iterated. Therefore `meta/run.yaml` is never processed and `/run/<config-name>` files are not generated. Fixed this by updating the ignore pattern to
```
/meta/*
```
which causes Capstan to ignore all files in `/meta`, but doesn't prevent it from iterating the folder.