### PR TITLE
Allow user to pass env variables for `capstan run`

### DIFF
--- a/test/runtime/runtime_test.go
+++ b/test/runtime/runtime_test.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2017 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package runtime_test
+
+import (
+	"testing"
+
+	"github.com/mikelangelo-project/capstan/runtime"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type testingRuntimeSuite struct{}
+
+var _ = Suite(&testingRuntimeSuite{})
+
+func (s *testingRuntimeSuite) TestPrependEnvsPrefix(c *C) {
+	m := []struct {
+		comment     string
+		cmd         string
+		env         map[string]string
+		expectedCmd string
+		err         string
+	}{
+		{
+			"no variable in environment",
+			"/node server.js",
+			map[string]string{},
+			"/node server.js",
+			"",
+		},
+		{
+			"single variable in environment",
+			"/node server.js",
+			map[string]string{"PORT": "8000"},
+			"--env=PORT=8000 /node server.js",
+			"",
+		},
+		{
+			"two variables in environment",
+			"/node server.js",
+			map[string]string{"PORT": "8000", "ENDPOINT": "foo.com"},
+			// Order is not guaranteed hence the following regex is needed:
+			"(--env=PORT=8000 --env=ENDPOINT=foo.com|--env=ENDPOINT=foo.com --env=PORT=8000) /node server.js",
+			"",
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// This is what we're testing here.
+		res, err := runtime.PrependEnvsPrefix(args.cmd, args.env)
+
+		// Expectations.
+		if args.err != "" {
+			c.Check(err, ErrorMatches, args.err)
+		} else {
+			c.Check(res, Matches, args.expectedCmd)
+		}
+	}
+}

--- a/test/util/parser_test.go
+++ b/test/util/parser_test.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2017 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package util_test
+
+import (
+	"testing"
+
+	"github.com/mikelangelo-project/capstan/util"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type testingParserSuite struct{}
+
+var _ = Suite(&testingParserSuite{})
+
+func (s *testingParserSuite) TestParseEnvironmentList(c *C) {
+	m := []struct {
+		comment     string
+		envList     []string
+		expectedRes map[string]string
+		err         string
+	}{
+		{
+			"no parameters",
+			[]string{},
+			map[string]string{},
+			"",
+		},
+		{
+			"single parameter",
+			[]string{"PORT=8000"},
+			map[string]string{"PORT": "8000"},
+			"",
+		},
+		{
+			"two parameters",
+			[]string{"PORT=8000", "ENDPOINT=foo.com"},
+			map[string]string{"PORT": "8000", "ENDPOINT": "foo.com"},
+			"",
+		},
+		{
+			"invalid char (space) #1",
+			[]string{"NAME=my name"},
+			map[string]string{},
+			"failed to parse --env argument .*",
+		},
+		{
+			"invalid char (space) #2",
+			[]string{"MY NAME=name"},
+			map[string]string{},
+			"failed to parse --env argument .*",
+		},
+		{
+			"invalid char (space) #3",
+			[]string{"MY NAME=my name"},
+			map[string]string{},
+			"failed to parse --env argument .*",
+		},
+		{
+			"value with equals sign #1",
+			[]string{"NAME=my=name"},
+			map[string]string{"NAME": "my=name"},
+			"",
+		},
+		{
+			"value with equals sign #2",
+			[]string{"NAME==name"},
+			map[string]string{"NAME": "=name"},
+			"",
+		},
+		{
+			"one parameter ok, other not",
+			[]string{"PORT=8000", "ENDPOINT=i am invalid"},
+			map[string]string{},
+			"failed to parse --env argument .*",
+		},
+		{
+			"same parameter two times",
+			[]string{"PORT=8000", "PORT=9999"},
+			map[string]string{"PORT": "9999"},
+			"",
+		},
+		{
+			"empty value",
+			[]string{"PORT="},
+			map[string]string{"PORT": ""},
+			"",
+		},
+		{
+			"not key=value format",
+			[]string{"PORT"},
+			map[string]string{},
+			"failed to parse --env argument .*",
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// This is what we're testing here.
+		res, err := util.ParseEnvironmentList(args.envList)
+
+		// Expectations.
+		if args.err != "" {
+			c.Check(err, ErrorMatches, args.err)
+		} else {
+			c.Check(res, DeepEquals, args.expectedRes)
+		}
+	}
+}

--- a/util/parser.go
+++ b/util/parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 func ParseMemSize(memory string) (int64, error) {
@@ -22,4 +23,21 @@ func ParseMemSize(memory string) (int64, error) {
 		return -1, fmt.Errorf("%s: memory size must be larger than zero", memory)
 	}
 	return size, nil
+}
+
+func ParseEnvironmentList(envList []string) (map[string]string, error) {
+	res := make(map[string]string)
+
+	for _, part := range envList {
+		if keyValue := strings.SplitN(part, "=", 2); len(keyValue) < 2 {
+			return nil, fmt.Errorf("failed to parse --env argument '%s': missing =", part)
+		} else if strings.Contains(keyValue[0], " ") {
+			return nil, fmt.Errorf("failed to parse --env argument '%s': key must not contain spaces", part)
+		} else if strings.Contains(keyValue[1], " ") {
+			return nil, fmt.Errorf("failed to parse --env argument '%s': value must not contain spaces", part)
+		} else {
+			res[keyValue[0]] = keyValue[1]
+		}
+	}
+	return res, nil
 }


### PR DESCRIPTION
This commit introduces argument `--env` that enables user to specify environment variables. Argument is repeatable, e.g.:
```bash
$ capstan run micro --boot master --env PORT=9292 --env ENDPOINT=kekec.si
```
This simply prepends environment variable stanza to the boot command so it can be used both with runscript (`--boot`) or when providing bootcmd directly (`--execute`).