### PR TITLE
Finalize capstanignore

### DIFF
--- a/core/capstanignore.go
+++ b/core/capstanignore.go
@@ -22,7 +22,9 @@ type Capstanignore interface {
 	IsIgnored(path string) bool
 }
 
-var CAPSTANIGNORE_ALWAYS []string = []string{"/meta/*", "/mpm-pkg", "/.git"}
+var CAPSTANIGNORE_ALWAYS []string = []string{
+	"/meta/*", "/mpm-pkg", "/.git", "/.capstanignore", "/.gitignore",
+}
 
 // CapstanignoreInit creates a new Capstanignore struct that is
 // used when deciding whether a file should be included in unikernel

--- a/core/capstanignore.go
+++ b/core/capstanignore.go
@@ -79,6 +79,12 @@ func (c *capstanignore) LoadFile(path string) error {
 
 // AddPattern adds a pattern to be ignored.
 func (c *capstanignore) AddPattern(pattern string) error {
+	// Protect user from strange behavior when ignoring whole /meta folder.
+	// (runscript files don't get created if ignored)
+	if pattern == "/meta" {
+		return fmt.Errorf("please remove '/meta' from .capstanignore")
+	}
+
 	safePattern := transformCapstanignoreToRegex(pattern)
 	if compiled, err := regexp.Compile(safePattern); err == nil {
 		c.patterns = append(c.patterns, pattern)

--- a/test/core/capstanignore_test.go
+++ b/test/core/capstanignore_test.go
@@ -152,6 +152,14 @@ func (s *testingCapstanignoreSuite) TestIsIgnored(c *C) {
 			"always ignore /.git",
 			"", "/.git", true,
 		},
+		{
+			"always ignore /.capstanignore",
+			"", "/.capstanignore", true,
+		},
+		{
+			"always ignore /.gitignore",
+			"", "/.gitignore", true,
+		},
 	}
 	for i, args := range m {
 		c.Logf("CASE #%d: %s", i, args.comment)

--- a/test/core/capstanignore_test.go
+++ b/test/core/capstanignore_test.go
@@ -175,3 +175,14 @@ func (s *testingCapstanignoreSuite) TestIsIgnored(c *C) {
 		c.Check(ignoreYesNo, Equals, args.shouldIgnore)
 	}
 }
+
+func (s *testingCapstanignoreSuite) TestIsIgnoredMeta(c *C) {
+	// Setup
+	capstanignore, _ := core.CapstanignoreInit("")
+
+	// This is what we're testing here.
+	err := capstanignore.AddPattern("/meta")
+
+	// Expectations.
+	c.Check(err, ErrorMatches, "please remove '/meta' from .capstanignore")
+}


### PR DESCRIPTION
Implementing two small improvements of capstanignore functionality that I came to think of when writing the first real `.capstanignore` file for osv-micorservice-demo project:

1) always ignore `.capstanignore` and `.gitignore`
2) protect user from adding `/meta` in her `.capstanignore` file (causes problems)