### PR TITLE
Fix "invalid tar header" when package is tar

### DIFF
--- a/cmd/package.go
+++ b/cmd/package.go
@@ -412,7 +412,7 @@ func extractPackageContent(pkgreader io.ReadSeeker, target, pkgName string) erro
 	if gzReader, err := gzip.NewReader(pkgreader); err == nil {
 		tarReader = tar.NewReader(gzReader)
 	} else if err == gzip.ErrHeader {
-		pkgreader.Seek(0, 0) // revert offset that gzReader has corrupted
+		pkgreader.Seek(0, io.SeekStart) // revert offset that gzReader has corrupted
 		tarReader = tar.NewReader(pkgreader)
 	} else {
 		return err

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -405,13 +405,14 @@ func ImportPackage(repo *util.Repo, packageDir string) error {
 	return repo.ImportPackage(pkg, packagePath)
 }
 
-func extractPackageContent(pkgreader io.Reader, target, pkgName string) error {
+func extractPackageContent(pkgreader io.ReadSeeker, target, pkgName string) error {
 	var tarReader *tar.Reader
 
 	// Load package (tar.gz or tar supported).
 	if gzReader, err := gzip.NewReader(pkgreader); err == nil {
 		tarReader = tar.NewReader(gzReader)
 	} else if err == gzip.ErrHeader {
+		pkgreader.Seek(0, 0) // revert offset that gzReader has corrupted
 		tarReader = tar.NewReader(pkgreader)
 	} else {
 		return err

--- a/util/repository.go
+++ b/util/repository.go
@@ -379,7 +379,7 @@ func (r *Repo) ImportPackage(pkg core.Package, packagePath string) error {
 	return nil
 }
 
-func (r *Repo) GetPackage(pkgname string) (io.Reader, error) {
+func (r *Repo) GetPackage(pkgname string) (io.ReadSeeker, error) {
 	pkgpath := r.PackagePath(pkgname)
 
 	// Make sure the package does exist.


### PR DESCRIPTION
Capstan supports both `tar.gz`-ed and `tar`-ed MPM packages. I came across a bug testing this: some tar packages couldn't be untarred properly. Turns out that tar.gz reader spoiled input stream offset when trying to decompress so falling back to tar reader didn't work correctly. Fixed by explicitly setting stream offset back to 0.
