### PR TITLE
Drop support for Go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.6
   - 1.7
   - 1.8
   - tip

--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -45,7 +45,7 @@ use it simply with `capstan --help`.
 
 ## Install Capstan from source (advanced)
 
-### Install Go 1.6+
+### Install Go 1.7+
 Capstan is a Go project and needs to be compiled first. But heads up, compiling Go project is trivial,
 as long as you have Go installed. Consult [official documentation](https://golang.org/doc/install)
 to learn how to install Go, or use this bash snippet to do it for you:

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/mikelangelo-project/capstan",
-	"GoVersion": "go1.6",
+	"GoVersion": "go1.7",
 	"Packages": [
 		"./..."
 	],


### PR DESCRIPTION
Since Go 1.6 is now quite old and we hit some missing functionality there, we simply drop support for it. The decision was made based on the fact that also other projects (Snap, Virtlet) don't support 1.6 anymore.