### PR TITLE
Use new package names internally and in documentation

### DIFF
--- a/Documentation/ApplicationManagement.md
+++ b/Documentation/ApplicationManagement.md
@@ -144,8 +144,8 @@ $ capstan runtime list
 
 RUNTIME             DESCRIPTION                                       DEPENDENCIES
 native              Run arbitrary command inside OSv                  []
-node                Run JavaScript NodeJS 4.4.5 application           [eu.mikelangelo-project.app.node-4.4.5]
-java                Run Java 1.7.0 application                        [eu.mikelangelo-project.osv.java]
+node                Run JavaScript NodeJS 4.4.5 application           [app.node-4.4.5]
+java                Run Java 1.7.0 application                        [osv.java]
 ```
 
 To generate template for `meta/run.yaml` go to your package root directory and execute command:
@@ -304,23 +304,23 @@ Interface) tool in our own application, initialise a package using
 ``--require`` option:
 
 ```
-$ capstan package init --name "com.example.app" --title "Example App" --author "Example User" --require eu.mikelangelo-project.osv.cli
+$ capstan package init --name "com.example.app" --title "Example App" --author "Example User" --require osv.cli
 ```
 
 The same can be achieved by manually adding one or more required packages in ``meta/package.yaml``:
 
 ```
-name: eu.mikelangelo-project.app.demo
+name: app.demo
 title: DEMO App
 author: lemmy
 require:
-    - eu.mikelangelo-project.osv.cli
+    - osv.cli
 ```
 
 When applications are composed, the required packages are recursively inspected
 and the content of all of them is added to the application. For example, the
-``eu.mikelangelo-project.osv.cli`` package requires
-``eu.mikelangelo-project.osv.httpserver`` which gets added automatically as
+``osv.cli`` package requires
+``osv.httpserver`` which gets added automatically as
 well.
 
 A package may override the content of any of its required packages which allows
@@ -337,13 +337,13 @@ refer to required packages.
 $ capstan package list
 
 Name                                               Description                    Version
-eu.mikelangelo-project.app.hadoop-hdfs             Hadoop HDFS                    2.7.2
-eu.mikelangelo-project.openfoam.core               OpenFOAM Core                  2.4.0
-eu.mikelangelo-project.openfoam.simplefoam         OpenFOAM simpleFoam            2.4.0
-eu.mikelangelo-project.osv.bootstrap               OSv Bootstrap                  0.24-46-g464f4e0
-eu.mikelangelo-project.osv.cli                     OSv Command Line Interface     0.24-46-g464f4e0
-eu.mikelangelo-project.osv.httpserver              OSv HTTP REST Server           0.24-46-g464f4e0
-eu.mikelangelo-project.osv.java                    Java JRE 1.7.0                 1.7.0-openjdk-1.7.0.60-2.4.7.4.fc20.x86_64
+app.hadoop-hdfs             Hadoop HDFS                    2.7.2
+openfoam.core               OpenFOAM Core                  2.4.0
+openfoam.simplefoam         OpenFOAM simpleFoam            2.4.0
+osv.bootstrap               OSv Bootstrap                  0.24-46-g464f4e0
+osv.cli                     OSv Command Line Interface     0.24-46-g464f4e0
+osv.httpserver              OSv HTTP REST Server           0.24-46-g464f4e0
+osv.java                    Java JRE 1.7.0                 1.7.0-openjdk-1.7.0.60-2.4.7.4.fc20.x86_64
 ```
 
 ### Collecting package content
@@ -454,11 +454,11 @@ If you have included CLI into your application, you may launch it right away:
 ```
 $ capstan run -e /cli/cli.so
 
-Updating image ``/home/lemmy/.capstan/repository/eu.mikelangelo-project.app.demo/eu.mikelangelo-project.app.demo.qemu...
+Updating image ``/home/lemmy/.capstan/repository/app.demo/app.demo.qemu...
 Setting cmdline: /tools/cpiod.so --prefix /
 Uploading files 287 / 287 [====================================================] 100.00 % 0
 All files uploaded
-Created instance: eu.mikelangelo-project.app.demo
+Created instance: app.demo
 Setting cmdline: /cli/cli.so
 OSv v0.24-78-g69bd35e
 eth0: 192.168.122.15
@@ -470,14 +470,14 @@ Goodbye
 
 Capstan provides support for composing and running Java-based applications. To
 enable Java application, one must add a dependency to
-``eu.mikelangelo-project.osv.java``, for example:
+``osv.java``, for example:
 
 ```
-name: eu.mikelangelo-project.app.hellojava
+name: app.hellojava
 title: Hello Java
 author: lemmy
 require:
-    - eu.mikelangelo-project.osv.java
+    - osv.java
 ```
 
 Additionally, you have to provide another manifest file configuring the Java

--- a/Documentation/Capstanignore.md
+++ b/Documentation/Capstanignore.md
@@ -66,7 +66,7 @@ case by using `--verbose` flag:
 ```bash
 $ capstan package collect --verbose
 Resolved runtime into: node
-Prepending 'node' runtime dependencies to dep list: [eu.mikelangelo-project.app.node-4.4.5]
+Prepending 'node' runtime dependencies to dep list: [app.node-4.4.5]
 .capstanignore: ignore /bin
 .capstanignore: ignore /bin/osv-launch-services.sh
 .capstanignore: ignore /bin/osv-launch-worker.sh

--- a/Documentation/ConfigurationFiles.md
+++ b/Documentation/ConfigurationFiles.md
@@ -21,7 +21,7 @@ name: my-super-application
 title: DEMO App
 author: lemmy (lemmy@email.com)
 require:
-    - eu.mikelangelo-project.osv.cli
+    - osv.cli
 ```
 The first three parameters are simple metadata and are used later if you decide to publish your
 application as a package to make it available for everyone. Be careful, though, that you pick unique
@@ -29,31 +29,31 @@ name for your package to avoid collisions with other users.
 
 The most interesting attribute is the one named `require`. This is where you list all the packages
 that you would like to have them included in your final unikernel. In this example we've listed only
-one, `eu.mikelangelo-project.osv.cli`. You can omit the whole attribute if you don't need any
+one, `osv.cli`. You can omit the whole attribute if you don't need any
 precompiled packages. A list of all packages in the remote repository can be obtained by executing:
 ```bash
 $ capstan package search
 Name                                               Description                       Version
-eu.mikelangelo-project.app.hadoop-hdfs             Hadoop HDFS                       2.7.2
-eu.mikelangelo-project.app.hello-node              NodeJS-4.4.5                      4.4.5
-eu.mikelangelo-project.app.mysql-5.6.21            MySQL-5.6.21                      5.6.21
-eu.mikelangelo-project.app.node-4.4.5              NodeJS-4.4.5                      4.4.5
-eu.mikelangelo-project.erlang                      Erlang                            18.0
-eu.mikelangelo-project.ompi                        Open MPI                          1.10
-eu.mikelangelo-project.openfoam.core               OpenFOAM Core                     2.4.0
-eu.mikelangelo-project.openfoam.pimplefoam         OpenFOAM pimpleFoam               2.4.0
-eu.mikelangelo-project.openfoam.pisofoam           OpenFOAM pisoFoam                 2.4.0
-eu.mikelangelo-project.openfoam.poroussimplefoam   OpenFOAM porousSimpleFoam         2.4.0
-eu.mikelangelo-project.openfoam.potentialfoam      OpenFOAM potentialFoam            2.4.0
-eu.mikelangelo-project.openfoam.rhoporoussimplefoam OpenFOAM rhoPorousSimpleFoam     2.4.0
-eu.mikelangelo-project.openfoam.rhosimplefoam      OpenFOAM rhoSimpleFoam            2.4.0
-eu.mikelangelo-project.openfoam.simplefoam         OpenFOAM simpleFoam               2.4.0
-eu.mikelangelo-project.osv.bootstrap               OSv Bootstrap                     v0.24-216-g1cf8972
-eu.mikelangelo-project.osv.cli                     OSv Command Line Interface        v0.24-216-g1cf8972
-eu.mikelangelo-project.osv.cloud-init              cloud-init                        v0.24-216-g1cf8972
-eu.mikelangelo-project.osv.httpserver              OSv HTTP REST Server              v0.24-216-g1cf8972
-eu.mikelangelo-project.osv.java                    Java JRE 1.7.0                    v0.24-216-g1cf8972
-eu.mikelangelo-project.osv.nfs                     OSv NFS Client Tools              v0.24-216-g1cf8972
+app.hadoop-hdfs             Hadoop HDFS                       2.7.2
+app.hello-node              NodeJS-4.4.5                      4.4.5
+app.mysql-5.6.21            MySQL-5.6.21                      5.6.21
+app.node-4.4.5              NodeJS-4.4.5                      4.4.5
+erlang                      Erlang                            18.0
+ompi                        Open MPI                          1.10
+openfoam.core               OpenFOAM Core                     2.4.0
+openfoam.pimplefoam         OpenFOAM pimpleFoam               2.4.0
+openfoam.pisofoam           OpenFOAM pisoFoam                 2.4.0
+openfoam.poroussimplefoam   OpenFOAM porousSimpleFoam         2.4.0
+openfoam.potentialfoam      OpenFOAM potentialFoam            2.4.0
+openfoam.rhoporoussimplefoam OpenFOAM rhoPorousSimpleFoam     2.4.0
+openfoam.rhosimplefoam      OpenFOAM rhoSimpleFoam            2.4.0
+openfoam.simplefoam         OpenFOAM simpleFoam               2.4.0
+osv.bootstrap               OSv Bootstrap                     v0.24-216-g1cf8972
+osv.cli                     OSv Command Line Interface        v0.24-216-g1cf8972
+osv.cloud-init              cloud-init                        v0.24-216-g1cf8972
+osv.httpserver              OSv HTTP REST Server              v0.24-216-g1cf8972
+osv.java                    Java JRE 1.7.0                    v0.24-216-g1cf8972
+osv.nfs                     OSv NFS Client Tools              v0.24-216-g1cf8972
 ```
 Then to download desired package into your local repository execute:
 ```bash
@@ -99,8 +99,8 @@ $ capstan runtime list
 
 RUNTIME    DESCRIPTION                                 DEPENDENCIES
 native     Run arbitrary command inside OSv            []
-node       Run JavaScript NodeJS 4.4.5 application     [eu.mikelangelo-project.app.node-4.4.5]
-java       Run Java 1.7.0 application                  [eu.mikelangelo-project.osv.java]
+node       Run JavaScript NodeJS 4.4.5 application     [app.node-4.4.5]
+java       Run Java 1.7.0 application                  [osv.java]
 ```
 And then Capstan can tell us what settings are supported for each runtime. For example, for NodeJS
 one can view expected content of the run.yaml file by executing:
@@ -156,7 +156,7 @@ $ capstan package init \
    --name "my-super-application" \
    --title "DEMO App" \
    --author "lemmy (lemmy@email.com)" \
-   --require eu.mikelangelo-project.osv.cli
+   --require osv.cli
 ```
 This will create a meta subdirectory and ``meta/package.yaml`` file with the
 given content. Then to initialize meta/run.yaml file, use:

--- a/Documentation/WalkthroughNodeJS.md
+++ b/Documentation/WalkthroughNodeJS.md
@@ -169,7 +169,7 @@ $ cd $PROJECT_ROOT
 $ capstan package compose com.example.word-finder --size 200MB
 (1)  Resolved runtime into: node
 (2)  Using named configuration: 'word_count'
-(3)  Prepending 'node' runtime dependencies to dep list: [eu.mikelangelo-project.app.node-4.4.5]
+(3)  Prepending 'node' runtime dependencies to dep list: [app.node-4.4.5]
 (4)  Importing com.example.word-finder...
 (5)  Importing into ...capstan/repository/com.example.word-finder/com.example.word-finder.qemu
 (6)  Uploading files to ...capstan/repository/com.example.word-finder/com.example.word-finder.qemu...

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -243,7 +243,7 @@ func CollectPackage(repo *util.Repo, packageDir string, pullMissing bool, custom
 	// The bootstrap package is implicitly required by every application package,
 	// so we add it to the list of required packages. Even if user has added
 	// the bootstrap manually, this will not result in overhead.
-	pkg.Require = append(pkg.Require, "eu.mikelangelo-project.osv.bootstrap")
+	pkg.Require = append(pkg.Require, "osv.bootstrap")
 
 	// Look for all dependencies and make sure they are all available in the repository.
 	requiredPackages, err := repo.GetPackageDependencies(pkg, pullMissing)

--- a/runtime/java.go
+++ b/runtime/java.go
@@ -31,10 +31,10 @@ func (conf javaRuntime) GetRuntimeName() string {
 	return string(Java)
 }
 func (conf javaRuntime) GetRuntimeDescription() string {
-	return "Run Java 1.7.0 application"
+	return "Run Java application"
 }
 func (conf javaRuntime) GetDependencies() []string {
-	return []string{"eu.mikelangelo-project.osv.java"}
+	return []string{"openjdk8-zulu-compact1"}
 }
 func (conf javaRuntime) Validate() error {
 	if conf.Main == "" {
@@ -75,7 +75,7 @@ main: <name>
 
 # REQUIRED
 # A list of paths where classes and other resources can be found.
-# Example value: classpath: 
+# Example value: classpath:
 #                   - /
 #                   - /package1
 classpath:
@@ -92,8 +92,8 @@ args:
 # OPTIONAL
 # A list of JVM args (e.g. Xmx, Xms)
 # Example value: jvmargs:
-#                   - Xmx1000m 
-#                   - Djava.net.preferIPv4Stack=true 
+#                   - Xmx1000m
+#                   - Djava.net.preferIPv4Stack=true
 #                   - Dhadoop.log.dir=/hdfs/logs
 jvmargs:
    <list>

--- a/runtime/node.go
+++ b/runtime/node.go
@@ -27,7 +27,7 @@ func (conf nodeJsRuntime) GetRuntimeDescription() string {
 	return "Run JavaScript NodeJS 4.4.5 application"
 }
 func (conf nodeJsRuntime) GetDependencies() []string {
-	return []string{"eu.mikelangelo-project.app.node-4.4.5"}
+	return []string{"node-4.4.5"}
 }
 func (conf nodeJsRuntime) Validate() error {
 	if conf.Main == "" {


### PR DESCRIPTION
Recently we've shorten MPM package names, namely we've stripped out the 'eu.mikelangelo-project.' prefix. This commit updates Capstan to use the new names.