### PR TITLE
Package documentation

### DIFF
--- a/capstan.go
+++ b/capstan.go
@@ -557,8 +557,10 @@ func main() {
 						packageName := c.Args()[0]
 
 						// Describe the package
-						if err := cmd.DescribePackage(repo, packageName); err != nil {
+						if s, err := cmd.DescribePackage(repo, packageName); err != nil {
 							return cli.NewExitError(err.Error(), EX_DATAERR)
+						} else {
+							fmt.Println(s)
 						}
 
 						return nil


### PR DESCRIPTION
This PR brings two improvements of `capstan package describe PACKAGE_NAME` command: first commit adds support for gzipped packages while the second commit prints content of package's `README.md` file.

It makes sense to print package's README.md file into console since this works on compressed package directly (so user doesn't need to extract it and manually look at it).

Example output is:
```bash
$ capstan package describe apache.spark
PACKAGE METADATA
name: apache.spark
title: Apache Spark
author: MIKELANGELO Project (info@mikelangelo-project.eu)
required packages:
   * openjdk8-zulu-compact3-with-java-beans

PACKAGE EXECUTION
runtime: native
default configuration: worker
-----------------------------------------
CONFIGURATION NAME        | BOOT COMMAND
-----------------------------------------
worker                    | --env=MASTER?=localhost:7077 /java.so -Xms512m -Xmx512m -cp /spark/conf:/spark/jars/* -Dscala.usejavacp=true org.apache.spark.deploy.worker.Worker $MASTER
master                    | /java.so -Xms512m -Xmx512m -cp /spark/conf:/spark/jars/* -Dscala.usejavacp=true org.apache.spark.deploy.master.Master --host 0.0.0.0 --port 7077 --webui-port 8080
-----------------------------------------

PACKAGE DOCUMENTATION
# Apache Spark 2.1.1 (on top of Hadoop 2.7.3)
## Description
This package provides logic for both Spark Master and Spark Worker.
Only difference between the two is bootcmd used to run the unikernel.

## Usage
Run master:
$ capstan run myspark --boot master

Run worker:
$ capstan run myspark --boot worker --env MASTER=localhost:7077
MASTER -> endpoint of your Spark master

## Limitations
This unikernel was tested on image size of 1GB.
```