### PR TITLE
Write recursive boot commands into /run directory

### DIFF
--- a/cmd/package.go
+++ b/cmd/package.go
@@ -416,7 +416,7 @@ func extractPackageContent(tarReader *tar.Reader, target, pkgName string) error 
 			return err
 		}
 
-		if header.Name == "meta/run.yaml" {
+		if header.Name == "/meta/run.yaml" {
 			// Prepare files with boot commands for this package.
 			data, err := ioutil.ReadAll(tarReader)
 			if err != nil {


### PR DESCRIPTION
When collecting the package the meta/run.yaml file gets parsed and each config_set is stored into a file. Using runscript utility of OSv kernel is then possible to boot OSv from that file.

With this commit we not only provide /run/<config-set-name> files for current package, but also for all recursive ones.