### PR TITLE
Safely handle filepaths of mpm packages

### DIFF
--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -294,6 +294,53 @@ config_set:
 	c.Check(filepath.Join(s.packageDir, "mpm-pkg", "run"), DirEquals, expectedBoots)
 }
 
+func (s *suite) TestAbsTarPathMatches(c *C) {
+	m := []struct {
+		comment     string
+		tarPath     string
+		pathPattern string
+		shouldMatch bool
+	}{
+		{
+			"absolute pattern #1",
+			"/meta/run.yaml", "/meta/run.yaml", true,
+		},
+		{
+			"absolute pattern #2",
+			"meta/run.yaml", "/meta/run.yaml", true,
+		},
+		{
+			"absolute pattern #3",
+			"mydir/meta/run.yaml", "/meta/run.yaml", false,
+		},
+		{
+			"relative pattern #1",
+			"/meta/run.yaml", "meta/run.yaml", true,
+		},
+		{
+			"relative pattern #2",
+			"meta/run.yaml", "meta/run.yaml", true,
+		},
+		{
+			"relative pattern #3",
+			"mydir/meta/run.yaml", "meta/run.yaml", false,
+		},
+		{
+			"all in dir",
+			"/meta/run.yaml", "/meta/.*", true,
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// This is what we're testing here.
+		match := absTarPathMatches(args.tarPath, args.pathPattern)
+
+		// Expectations.
+		c.Check(match, Equals, args.shouldMatch)
+	}
+}
+
 //
 // Utility
 //


### PR DESCRIPTION
There was a following problem with filepaths when Capstan was iterating tar: sometimes path was prefixed with '/' and sometimes not. Here is how one can reproduce both scenarios:

1. create mpm for arbitrary package using `capstan package build` to obtain demo.mpm
2. all paths in demo.mpm are prefixed with '/'
3. rename demo.mpm into demo.tar.gz and double-click it in Nautilus File Browser
4. in the popup that appears modify arbitrary file
5. rename demo.tar.gz back into demo.mpm
6. path of the updated file is not not prefixed with '/' anymore

With this commit we handle the problem in a way that we match both prefixed and unprefixed path.
