### PR TITLE
Support --env argument for `capstan package compose` command

### DIFF
--- a/cmd/package.go
+++ b/cmd/package.go
@@ -153,8 +153,8 @@ func BuildPackage(packageDir string) (string, error) {
 // by comparing previous MD5 hashes to the ones in the current package
 // directory. Only modified files are uploaded and no file deletions are
 // possible at this time.
-func ComposePackage(repo *util.Repo, imageSize int64, updatePackage bool, verbose bool,
-	pullMissing bool, customBoot string, packageDir string, appName string, commandLine string) error {
+func ComposePackage(repo *util.Repo, imageSize int64, updatePackage, verbose, pullMissing bool,
+	packageDir, appName string, bootOpts *BootOptions) error {
 
 	// Package content should be collected in a subdirectory called mpm-pkg.
 	targetPath := filepath.Join(packageDir, "mpm-pkg")
@@ -162,10 +162,13 @@ func ComposePackage(repo *util.Repo, imageSize int64, updatePackage bool, verbos
 	defer os.RemoveAll(targetPath)
 
 	// Construct final bootcmd for the image.
-	commandLine = constructBootCmdFromArguments(commandLine, customBoot, packageDir)
+	commandLine, err := bootOpts.GetCmd()
+	if err != nil {
+		return err
+	}
 
 	// First, collect the contents of the package.
-	if err := CollectPackage(repo, packageDir, pullMissing, customBoot, verbose); err != nil {
+	if err := CollectPackage(repo, packageDir, pullMissing, bootOpts.Boot, verbose); err != nil {
 		return err
 	}
 
@@ -659,32 +662,46 @@ func persistBootCmdsIntoFiles(runYamlData []byte, mpmFolder, customBoot string, 
 	return nil
 }
 
-// constructBootCmdFromArguments builds bootcmd based on three parameters (in this order):
+type BootOptions struct {
+	Cmd        string
+	Boot       string
+	EnvList    []string
+	PackageDir string
+}
+
+// GetCmd builds final bootcmd based on three parameters (in this order):
 // * --run <commandLine>
 // * --boot <customBoot>
 // * config_set_default: <> (read from meta/run.yaml within packageDir)
-func constructBootCmdFromArguments(commandLine, customBoot, packageDir string) string {
-	// Direct commandLine has highest priority (--run <commandLine>).
-	if commandLine != "" {
+func (b *BootOptions) GetCmd() (string, error) {
+	command := ""
+
+	if b.Cmd != "" { // Direct commandLine has highest priority (--run <commandLine>).
 		fmt.Println("Command line will be set based on --run parameter")
-		return commandLine
-	}
-
-	// Configuration name has second-highest priority (--boot <customBoot>).
-	if customBoot != "" {
+		command = b.Cmd
+	} else if b.Boot != "" { // Configuration name has second-highest priority (--boot <customBoot>).
 		fmt.Println("Command line will be set based on --boot parameter")
-		return runtime.BootCmdForScript(customBoot)
-	}
-
-	// Default configuration in yaml has third-highest priority (config_set_default: <>).
-	if data, err := ioutil.ReadFile(filepath.Join(packageDir, "meta", "run.yaml")); err == nil {
-		if cmdConf, err := core.ParsePackageRunManifestData(data); err == nil && cmdConf.ConfigSetDefault != "" {
-			fmt.Println("Command line will be set based on config_set_default attribute of meta/run.yaml")
-			return runtime.BootCmdForScript(cmdConf.ConfigSetDefault)
+		command = runtime.BootCmdForScript(b.Boot)
+	} else if b.PackageDir != "" { // Default configuration in yaml has third-highest priority (config_set_default: <>).
+		if data, err := ioutil.ReadFile(filepath.Join(b.PackageDir, "meta", "run.yaml")); err == nil {
+			if cmdConf, err := core.ParsePackageRunManifestData(data); err == nil && cmdConf.ConfigSetDefault != "" {
+				fmt.Println("Command line will be set based on config_set_default attribute of meta/run.yaml")
+				command = runtime.BootCmdForScript(cmdConf.ConfigSetDefault)
+			}
 		}
+	} else { // Fallback is empty bootcmd.
+		fmt.Println("Empty command line will be set for this image")
+		command = ""
 	}
 
-	// Fallback is empty bootcmd.
-	fmt.Println("Empty command line will be set for this image")
-	return ""
+	// Prepend environment variables to the command.
+	if env, err := util.ParseEnvironmentList(b.EnvList); err == nil {
+		if command, err = runtime.PrependEnvsPrefix(command, env, false); err != nil {
+			return "", err
+		}
+	} else {
+		return "", err
+	}
+
+	return command, nil
 }

--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -107,7 +107,7 @@ func (*suite) TestComposeNonPackageFails(c *C) {
 	imageSize, _ := util.ParseMemSize("64M")
 	appName := "test-app"
 
-	err := ComposePackage(repo, imageSize, false, false, false, "", tmp, appName, "")
+	err := ComposePackage(repo, imageSize, false, false, false, tmp, appName, &BootOptions{})
 
 	c.Assert(err, NotNil)
 }
@@ -128,7 +128,7 @@ func (*suite) TestComposeCorruptPackageFails(c *C) {
 	imageSize, _ := util.ParseMemSize("64M")
 	appName := "test-app"
 
-	err = ComposePackage(repo, imageSize, false, false, false, "", tmp, appName, "")
+	err = ComposePackage(repo, imageSize, false, false, false, tmp, appName, &BootOptions{})
 	c.Assert(err, NotNil)
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -10,6 +10,12 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
 	"github.com/mikelangelo-project/capstan/core"
 	"github.com/mikelangelo-project/capstan/hypervisor/gce"
 	"github.com/mikelangelo-project/capstan/hypervisor/qemu"
@@ -18,11 +24,6 @@ import (
 	"github.com/mikelangelo-project/capstan/image"
 	"github.com/mikelangelo-project/capstan/runtime"
 	"github.com/mikelangelo-project/capstan/util"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 )
 
 func RunInstance(repo *util.Repo, config *runtime.RunConfig) error {
@@ -170,7 +171,8 @@ func RunInstance(repo *util.Repo, config *runtime.RunConfig) error {
 			if err != nil {
 				return err
 			}
-			err = ComposePackage(repo, sz, true, false, true, "", wd, pkg.Name, config.Cmd)
+			bootOpts := BootOptions{Boot: config.Cmd}
+			err = ComposePackage(repo, sz, true, false, true, wd, pkg.Name, &bootOpts)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -10,10 +10,11 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/mikelangelo-project/capstan/provider/openstack"
 	"github.com/mikelangelo-project/capstan/util"
 	"github.com/urfave/cli"
-	"os"
 )
 
 // OpenStackPush picks best flavor, composes package, builds .qcow2 image and uploads it to OpenStack.
@@ -62,9 +63,16 @@ func OpenStackPush(c *cli.Context) error {
 	// flavor.Disk is in GB, we need MB
 	sizeMB := 1024 * int64(flavor.Disk)
 
+	bootOpts := BootOptions{
+		Cmd:        c.String("run"),
+		Boot:       c.String("boot"),
+		EnvList:    c.StringSlice("env"),
+		PackageDir: packageDir,
+	}
+
 	// Compose image locally.
 	fmt.Printf("Creating image of user-usable size %d MB.\n", sizeMB)
-	err = ComposePackage(repo, sizeMB, false, verbose, pullMissing, c.String("boot"), packageDir, appName, c.String("run"))
+	err = ComposePackage(repo, sizeMB, false, verbose, pullMissing, packageDir, appName, &bootOpts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Similarly as it's already implemented for `capstan run` we want to be able to accept environment variables here. We need this when we want to compose unikernel with specific bootcmd and run it elsewhere (e.g. on openstack).

To support such functionality we do a little refactoring. There were too many flags walking around the code and with the refactoring we encapsulate them into a struct named SimpleBootOptions. This way we centralize work related to building boot command. Having this done, it was simple to support --env also for `package compose` command.

The effect is as follows:
```
# BEFORE
# We couldn't use --boot flag if we wanted to set environment variables
$ capstan package compose demo --run "--env=MASTER=172.16.122.3:7077 runscript /run/worker"

# NOW
# We can use --boot flag and enrich it with --env flag
$ capstan package compose demo --boot worker --env MASTER=172.16.122.3:7077
```
