### PR TITLE
Check any permutation of --env prefix in tests

### DIFF
--- a/test/runtime/runtime_test.go
+++ b/test/runtime/runtime_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/mikelangelo-project/capstan/runtime"
+	. "github.com/mikelangelo-project/capstan/testing"
 	. "gopkg.in/check.v1"
 )
 
@@ -27,56 +28,43 @@ func (s *testingRuntimeSuite) TestPrependEnvsPrefix(c *C) {
 		env         map[string]string
 		soft        bool
 		expectedCmd string
+		expectedEnv []string
 		err         string
 	}{
 		{
 			"no variable in environment",
-			"/node server.js",
-			map[string]string{},
-			false,
-			"/node server.js",
+			"/node server.js", map[string]string{}, false,
+			"/node server.js", []string{},
 			"",
 		},
 		{
 			"single variable in environment",
-			"/node server.js",
-			map[string]string{"PORT": "8000"},
-			false,
-			"--env=PORT=8000 /node server.js",
+			"/node server.js", map[string]string{"PORT": "8000"}, false,
+			"/node server.js", []string{"--env=PORT=8000"},
 			"",
 		},
 		{
 			"two variables in environment",
-			"/node server.js",
-			map[string]string{"PORT": "8000", "ENDPOINT": "foo.com"},
-			false,
-			// Order is not guaranteed hence the following regex is needed:
-			"(--env=PORT=8000 --env=ENDPOINT=foo.com|--env=ENDPOINT=foo.com --env=PORT=8000) /node server.js",
+			"/node server.js", map[string]string{"PORT": "8000", "ENDPOINT": "foo.com"}, false,
+			"/node server.js", []string{"--env=PORT=8000", "--env=ENDPOINT=foo.com"},
 			"",
 		},
 		{
 			"no variable in environment - soft",
-			"/node server.js",
-			map[string]string{},
-			true,
-			"/node server.js",
+			"/node server.js", map[string]string{}, true,
+			"/node server.js", []string{},
 			"",
 		},
 		{
 			"single variable in environment - soft",
-			"/node server.js",
-			map[string]string{"PORT": "8000"},
-			true,
-			"--env=PORT\\?=8000 /node server.js",
+			"/node server.js", map[string]string{"PORT": "8000"}, true,
+			"/node server.js", []string{"--env=PORT?=8000"},
 			"",
 		},
 		{
 			"two variables in environment - soft",
-			"/node server.js",
-			map[string]string{"PORT": "8000", "ENDPOINT": "foo.com"},
-			true,
-			// Order is not guaranteed hence the following regex is needed:
-			"(--env=PORT\\?=8000 --env=ENDPOINT\\?=foo.com|--env=ENDPOINT\\?=foo.com --env=PORT\\?=8000) /node server.js",
+			"/node server.js", map[string]string{"PORT": "8000", "ENDPOINT": "foo.com"}, true,
+			"/node server.js", []string{"--env=PORT?=8000", "--env=ENDPOINT?=foo.com"},
 			"",
 		},
 	}
@@ -90,7 +78,7 @@ func (s *testingRuntimeSuite) TestPrependEnvsPrefix(c *C) {
 		if args.err != "" {
 			c.Check(err, ErrorMatches, args.err)
 		} else {
-			c.Check(res, Matches, args.expectedCmd)
+			c.Check(res, BootCmdEquals, args.expectedCmd, args.expectedEnv)
 		}
 	}
 }


### PR DESCRIPTION
Capstan prepends environment variables to the boot command based on map[env_name]string where order is not always the same. Therefore we implement a specialized BootCmdEquals checker that compares obtained bootcmd string with given bootcmd base and environment map.

NOTE: This change is already included in https://github.com/mikelangelo-project/capstan/pull/37, but since it affects many lines, it will be better to merge it here and then rebase the PR regarding recursive run.yamls.