### PR TITLE
Support package bootcmd inheritance

### DIFF
--- a/runtime/java.go
+++ b/runtime/java.go
@@ -37,19 +37,23 @@ func (conf javaRuntime) GetDependencies() []string {
 	return []string{"openjdk8-zulu-compact1"}
 }
 func (conf javaRuntime) Validate() error {
-	if conf.Main == "" {
-		return fmt.Errorf("'main' must be provided")
+	inherit := conf.Base != ""
+
+	if !inherit {
+		if conf.Main == "" {
+			return fmt.Errorf("'main' must be provided")
+		}
+
+		if conf.Classpath == nil {
+			return fmt.Errorf("'classpath' must be provided")
+		}
 	}
 
-	if conf.Classpath == nil {
-		return fmt.Errorf("'classpath' must be provided")
-	}
-
-	return conf.CommonRuntime.Validate()
+	return conf.CommonRuntime.Validate(inherit)
 }
-func (conf javaRuntime) GetBootCmd() (string, error) {
+func (conf javaRuntime) GetBootCmd(cmdConfs map[string]*CmdConfig, env map[string]string) (string, error) {
 	cmd := fmt.Sprintf("java.so %s io.osv.isolated.MultiJarLoader -mains /etc/javamains", conf.GetJvmArgs())
-	return conf.CommonRuntime.BuildBootCmd(cmd)
+	return conf.CommonRuntime.BuildBootCmd(cmd, cmdConfs, env)
 }
 func (conf javaRuntime) OnCollect(targetPath string) error {
 	// Check if /etc folder is already available. This is where we are going to store

--- a/runtime/native.go
+++ b/runtime/native.go
@@ -7,9 +7,7 @@
 
 package runtime
 
-import (
-	"fmt"
-)
+import "fmt"
 
 type nativeRuntime struct {
 	CommonRuntime `yaml:"-,inline"`
@@ -30,15 +28,19 @@ func (conf nativeRuntime) GetDependencies() []string {
 	return []string{}
 }
 func (conf nativeRuntime) Validate() error {
-	if conf.BootCmd == "" {
-		return fmt.Errorf("'bootcmd' must be provided")
+	inherit := conf.Base != ""
+
+	if !inherit {
+		if conf.BootCmd == "" {
+			return fmt.Errorf("'bootcmd' must be provided")
+		}
 	}
 
-	return conf.CommonRuntime.Validate()
+	return conf.CommonRuntime.Validate(inherit)
 }
-func (conf nativeRuntime) GetBootCmd() (string, error) {
+func (conf nativeRuntime) GetBootCmd(cmdConfs map[string]*CmdConfig, env map[string]string) (string, error) {
 	cmd := conf.BootCmd
-	return conf.CommonRuntime.BuildBootCmd(cmd)
+	return conf.CommonRuntime.BuildBootCmd(cmd, cmdConfs, env)
 }
 func (conf nativeRuntime) OnCollect(targetPath string) error {
 	return nil

--- a/runtime/node.go
+++ b/runtime/node.go
@@ -30,15 +30,19 @@ func (conf nodeJsRuntime) GetDependencies() []string {
 	return []string{"node-4.4.5"}
 }
 func (conf nodeJsRuntime) Validate() error {
-	if conf.Main == "" {
-		return fmt.Errorf("'main' must be provided")
+	inherit := conf.Base != ""
+
+	if !inherit {
+		if conf.Main == "" {
+			return fmt.Errorf("'main' must be provided")
+		}
 	}
 
-	return conf.CommonRuntime.Validate()
+	return conf.CommonRuntime.Validate(inherit)
 }
-func (conf nodeJsRuntime) GetBootCmd() (string, error) {
+func (conf nodeJsRuntime) GetBootCmd(cmdConfs map[string]*CmdConfig, env map[string]string) (string, error) {
 	cmd := fmt.Sprintf("node %s", conf.Main)
-	return conf.CommonRuntime.BuildBootCmd(cmd)
+	return conf.CommonRuntime.BuildBootCmd(cmd, cmdConfs, env)
 }
 func (conf nodeJsRuntime) OnCollect(targetPath string) error {
 	return nil

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/mikelangelo-project/capstan/nat"
+	"github.com/mikelangelo-project/capstan/util"
 )
 
 type RuntimeType string
@@ -51,8 +52,10 @@ type Runtime interface {
 	// Validate values that were read from yaml.
 	Validate() error
 
-	// GetBootCmd produces bootcmd based on meta/run.yaml.
-	GetBootCmd() (string, error)
+	// GetBootCmd produces bootcmd based on meta/run.yaml. The cmdConfs
+	// argument contains CmdConfig objects for all required packages and
+	// can be used when building boot command.
+	GetBootCmd(cmdConfs map[string]*CmdConfig, env map[string]string) (string, error)
 
 	// GetRuntimeName returns unique runtime name
 	// (use constant from the SupportedRuntimes list)
@@ -74,20 +77,14 @@ type Runtime interface {
 
 	// GetDependencies returns a list of dependent package names.
 	GetDependencies() []string
-
-	// GetEnv returns map of environment variables read from run.yaml.
-	GetEnv() map[string]string
 }
 
 // CommonRuntime fields are those common to all runtimes.
 // This fields are set for each named-configuration separately, nothing
 // is shared.
 type CommonRuntime struct {
-	Env map[string]string `yaml:"env"`
-}
-
-func (r CommonRuntime) GetEnv() map[string]string {
-	return r.Env
+	Env  map[string]string `yaml:"env"`
+	Base string            `yaml:"base"`
 }
 
 func (r CommonRuntime) GetYamlTemplate() string {
@@ -100,27 +97,69 @@ func (r CommonRuntime) GetYamlTemplate() string {
 #                    HOSTNAME: www.myserver.org
 env:
    <key>: <value>
+
+# OPTIONAL
+# Configuration to contextualize.
+base: "<package-name>:<config_set>"
 `
 }
 
-func (r CommonRuntime) Validate() error {
+func (r CommonRuntime) Validate(inherit bool) error {
 	for k, v := range r.Env {
 		if strings.Contains(k, " ") || strings.Contains(v, " ") {
 			return fmt.Errorf("spaces not allowed in env key/value: '%s':'%s'", k, v)
 		}
 	}
+
+	if inherit {
+		if r.Base == "" {
+			return fmt.Errorf("'base' must be provided")
+		}
+		if !strings.Contains(r.Base, ":") {
+			return fmt.Errorf("'base' must be in format <pkg_name>:<config_set>")
+		}
+	}
+
 	return nil
 }
 
 // BuildBootCmd equips runtime-specific bootcmd with common parts.
-func (r CommonRuntime) BuildBootCmd(bootCmd string) (string, error) {
+func (r CommonRuntime) BuildBootCmd(bootCmd string, cmdConfs map[string]*CmdConfig, env map[string]string) (string, error) {
+	util.ExtendMap(env, r.Env)
+
+	if r.Base != "" {
+		return r.inheritBootCmd(cmdConfs, env)
+	}
+
 	// Prepend environment variables
-	newBootCmd, err := PrependEnvsPrefix(bootCmd, r.GetEnv(), true)
+	newBootCmd, err := PrependEnvsPrefix(bootCmd, env, true)
 	if err != nil {
 		return "", err
 	}
 
 	return newBootCmd, nil
+}
+
+// inheritBootCmd builds boot command based on the package referenced by "base".
+func (r CommonRuntime) inheritBootCmd(cmdConfs map[string]*CmdConfig, env map[string]string) (string, error) {
+	parts := strings.SplitN(r.Base, ":", 2)
+	pkgName := parts[0]
+	configSet := parts[1]
+
+	if _, exists := cmdConfs[pkgName]; !exists || cmdConfs[pkgName] == nil {
+		return "", fmt.Errorf("Failed to inherit from '%s': package not included or has no meta/run.yaml", pkgName)
+	}
+	if _, exists := cmdConfs[pkgName].ConfigSets[configSet]; !exists {
+		return "", fmt.Errorf("Failed to inherit '%s:%s': config_set does not exist", pkgName, configSet)
+	}
+
+	original := cmdConfs[pkgName].ConfigSets[configSet]
+	bootCmd, err := original.GetBootCmd(cmdConfs, env)
+	if err != nil {
+		return "", err
+	}
+
+	return bootCmd, nil
 }
 
 // PickRuntime maps runtime name into runtime struct.

--- a/util/util.go
+++ b/util/util.go
@@ -148,3 +148,15 @@ func RemoveOrphanedInstances(verbose bool) error {
 
 	return nil
 }
+
+func ExtendMap(m map[string]string, additional map[string]string) {
+	if m == nil || additional == nil {
+		return
+	}
+
+	for key, value := range additional {
+		if _, exists := m[key]; !exists {
+			m[key] = value
+		}
+	}
+}


### PR DESCRIPTION
With this commit we support contextualization of required package's boot configuration. For example, if we require a package node-4.4.5 that contains following meta/run.yaml:
```yaml
runtime: native
config_set:
  node:
    bootcmd:  /node $NODE_ARGS $MAIN $ARGS
    NODE_ARGS: --no-deprecation
```
then we are now able to reference it from our own meta/run.yaml using 'base' attribute like this:
```yaml
runtime: native
config_set:
  medo:
    base: "node-4.4.5:node"
    env:
      MAIN: /medo-application.js
      ARGS: 127.0.0.1
```
and it will result in following script being created:
```
# /run/medo 
--env=MAIN?=/medo-application.js --env=NODE_ARGS?=--no-deprecation --env=ARGS?=127.0.0.1 /node $NODE_ARGS $MAIN $ARGS
```

Depends on https://github.com/mikelangelo-project/capstan/pull/44