### PR TITLE
Rewrite Java runtime to make use of config_set inheritance

### DIFF
--- a/runtime/java.go
+++ b/runtime/java.go
@@ -9,18 +9,17 @@ package runtime
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"strings"
 )
 
 type javaRuntime struct {
 	CommonRuntime `yaml:"-,inline"`
+	Xms           string   `yaml:"xms"`
+	Xmx           string   `yaml:"xmx"`
+	Classpath     []string `yaml:"classpath"`
+	JvmArgs       []string `yaml:"jvm_args"`
 	Main          string   `yaml:"main"`
 	Args          []string `yaml:"args"`
-	Classpath     []string `yaml:"classpath"`
-	JvmArgs       []string `yaml:"jvmargs"`
 }
 
 //
@@ -52,23 +51,18 @@ func (conf javaRuntime) Validate() error {
 	return conf.CommonRuntime.Validate(inherit)
 }
 func (conf javaRuntime) GetBootCmd(cmdConfs map[string]*CmdConfig, env map[string]string) (string, error) {
-	cmd := fmt.Sprintf("java.so %s io.osv.isolated.MultiJarLoader -mains /etc/javamains", conf.GetJvmArgs())
-	return conf.CommonRuntime.BuildBootCmd(cmd, cmdConfs, env)
-}
-func (conf javaRuntime) OnCollect(targetPath string) error {
-	// Check if /etc folder is already available. This is where we are going to store
-	// Java launch definition.
-	etcDir := filepath.Join(targetPath, "etc")
-	if _, err := os.Stat(etcDir); os.IsNotExist(err) {
-		os.MkdirAll(etcDir, 0777)
+	if conf.Base == "" { // Allow user to use e.g. "openjdk7:java" package instead default one.
+		conf.Base = "openjdk8-zulu-compact1:java"
 	}
-
-	err := ioutil.WriteFile(filepath.Join(etcDir, "javamains"), []byte(conf.GetCommandLine()), 0644)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	conf.setDefaultEnv(map[string]string{
+		"XMS":       conf.Xms,
+		"XMX":       conf.Xmx,
+		"CLASSPATH": strings.Join(conf.Classpath, ":"),
+		"JVM_ARGS":  conf.concatJvmArgs(),
+		"MAIN":      conf.Main,
+		"ARGS":      strings.Join(conf.Args, " "),
+	})
+	return conf.CommonRuntime.BuildBootCmd("", cmdConfs, env)
 }
 func (conf javaRuntime) GetYamlTemplate() string {
 	return `
@@ -83,7 +77,21 @@ main: <name>
 #                   - /
 #                   - /package1
 classpath:
-   <list>
+   - <list>
+
+# OPTIONAL
+# Initial and maximum JVM memory size.
+# Example value: xms: 512m
+xms: <value>
+xmx: <value>
+
+# OPTIONAL
+# A list of JVM args.
+# Example value: jvm_args:
+#                   - -Djava.net.preferIPv4Stack=true
+#                   - -Dhadoop.log.dir=/hdfs/logs
+jvm_args:
+   - <list>
 
 # OPTIONAL
 # A list of command line args used by the application.
@@ -91,16 +99,7 @@ classpath:
 #                   - argument1
 #                   - argument2
 args:
-   <list>
-
-# OPTIONAL
-# A list of JVM args (e.g. Xmx, Xms)
-# Example value: jvmargs:
-#                   - Xmx1000m
-#                   - Djava.net.preferIPv4Stack=true
-#                   - Dhadoop.log.dir=/hdfs/logs
-jvmargs:
-   <list>
+   - <list>
 ` + conf.CommonRuntime.GetYamlTemplate()
 }
 
@@ -108,25 +107,13 @@ jvmargs:
 // Utility
 //
 
-func (conf javaRuntime) GetCommandLine() string {
-	var cp, args string
-
-	if len(conf.Classpath) > 0 {
-		cp = "-cp " + strings.Join(conf.Classpath, ":")
+func (conf javaRuntime) concatJvmArgs() string {
+	if len(conf.JvmArgs) > 0 {
+		return strings.Join(conf.JvmArgs, " ")
+	} else {
+		// This is a workaround since runscript is currently unable to
+		// handle empty environment variable as a parameter. So we set
+		// dummy value unless user provided some actual value.
+		return "-Dx=y"
 	}
-
-	if len(conf.Args) > 0 {
-		args = strings.Join(conf.Args, " ")
-	}
-
-	return strings.TrimSpace(fmt.Sprintf("%s %s %s", cp, conf.Main, args))
-}
-func (conf javaRuntime) GetJvmArgs() string {
-	vmargs := ""
-
-	for _, arg := range conf.JvmArgs {
-		vmargs += fmt.Sprintf("-%s ", arg)
-	}
-
-	return strings.TrimSpace(vmargs)
 }

--- a/runtime/java_test.go
+++ b/runtime/java_test.go
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2017 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package runtime
+
+import (
+	"testing"
+
+	. "github.com/mikelangelo-project/capstan/testing"
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type javaSuite struct {
+}
+
+var _ = Suite(&javaSuite{})
+
+func (*javaSuite) TestGetBootCmd(c *C) {
+	// Simulate openjdk8-zulu-compact1's meta/run.yaml being parsed.
+	cmdConfs := map[string]*CmdConfig{
+		"openjdk8-zulu-compact1": &CmdConfig{
+			RuntimeType:      Native,
+			ConfigSetDefault: "java",
+			ConfigSets: map[string]Runtime{
+				"java": nativeRuntime{
+					BootCmd: "/java.so",
+					CommonRuntime: CommonRuntime{
+						Env: map[string]string{
+							"XMS":       "512m",
+							"XMX":       "512m",
+							"CLASSPATH": "/",
+							"JVM_ARGS":  "-Duser.dir=/",
+							"MAIN":      "main.Hello",
+							"ARGS":      "",
+						},
+					},
+				},
+			},
+		},
+		"openjdk7": &CmdConfig{
+			RuntimeType:      Native,
+			ConfigSetDefault: "java",
+			ConfigSets: map[string]Runtime{
+				"java": nativeRuntime{
+					BootCmd: "/java7.so",
+					CommonRuntime: CommonRuntime{
+						Env: map[string]string{
+							"XMS":       "512m",
+							"XMX":       "512m",
+							"CLASSPATH": "/",
+							"JVM_ARGS":  "-Duser.dir=/",
+							"MAIN":      "main.Hello",
+							"ARGS":      "",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	m := []struct {
+		comment      string
+		runYamlText  string
+		expectedBoot string
+		expectedEnv  []string
+	}{
+		{
+			"simple",
+			`
+			runtime: java
+			config_set:
+			  default:
+			    main: demo.Main
+			    classpath:
+			      - /src
+			`,
+			"/java.so", []string{
+				"--env=XMS?=512m",
+				"--env=XMX?=512m",
+				"--env=CLASSPATH?=/src",
+				"--env=JVM_ARGS?=-Dx=y",
+				"--env=MAIN?=demo.Main",
+				"--env=ARGS?=",
+			},
+		},
+		{
+			"multiple classpath",
+			`
+			runtime: java
+			config_set:
+			  default:
+			    main: demo.Main
+			    classpath:
+			      - /src
+			      - /src/package1
+			`,
+			"/java.so", []string{
+				"--env=XMS?=512m",
+				"--env=XMX?=512m",
+				"--env=CLASSPATH?=/src:/src/package1",
+				"--env=JVM_ARGS?=-Dx=y",
+				"--env=MAIN?=demo.Main",
+				"--env=ARGS?=",
+			},
+		},
+		{
+			"xms and xmx",
+			`
+			runtime: java
+			config_set:
+			  default:
+			    main: demo.Main
+			    classpath:
+			      - /src
+			    xms: 128m
+			    xmx: 1024m
+			`,
+			"/java.so", []string{
+				"--env=XMS?=128m",
+				"--env=XMX?=1024m",
+				"--env=CLASSPATH?=/src",
+				"--env=JVM_ARGS?=-Dx=y",
+				"--env=MAIN?=demo.Main",
+				"--env=ARGS?=",
+			},
+		},
+		{
+			"jvm args",
+			`
+			runtime: java
+			config_set:
+			  default:
+			    main: demo.Main
+			    classpath:
+			      - /src
+			    jvm_args:
+			      - -Darg1=val1
+			      - -Darg2=val2
+			`,
+			"/java.so", []string{
+				"--env=XMS?=512m",
+				"--env=XMX?=512m",
+				"--env=CLASSPATH?=/src",
+				"--env=JVM_ARGS?=-Darg1=val1 -Darg2=val2",
+				"--env=MAIN?=demo.Main",
+				"--env=ARGS?=",
+			},
+		},
+		{
+			"args",
+			`
+			runtime: java
+			config_set:
+			  default:
+			    main: demo.Main
+			    classpath:
+			      - /src
+			    args:
+			      - localhost
+			      - 8000
+			`,
+			"/java.so", []string{
+				"--env=XMS?=512m",
+				"--env=XMX?=512m",
+				"--env=CLASSPATH?=/src",
+				"--env=JVM_ARGS?=-Dx=y",
+				"--env=MAIN?=demo.Main",
+				"--env=ARGS?=localhost 8000",
+			},
+		},
+		{
+			"different base package",
+			`
+			runtime: java
+			config_set:
+			  default:
+			    base: "openjdk7:java"
+			    main: demo.Main
+			    classpath:
+			      - /src
+			`,
+			"/java7.so", []string{
+				"--env=XMS?=512m",
+				"--env=XMX?=512m",
+				"--env=CLASSPATH?=/src",
+				"--env=JVM_ARGS?=-Dx=y",
+				"--env=MAIN?=demo.Main",
+				"--env=ARGS?=",
+			},
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare
+		cmdConfig, err := ParsePackageRunManifestData([]byte(FixIndent(args.runYamlText)))
+		testRuntime, _ := cmdConfig.selectConfigSetByName("default")
+
+		// This is what we're testing here.
+		boot, err := testRuntime.GetBootCmd(cmdConfs, map[string]string{})
+
+		// Expectations.
+		c.Assert(err, IsNil)
+		c.Check(boot, BootCmdEquals, args.expectedBoot, args.expectedEnv)
+	}
+}
+
+func (*javaSuite) TestValidate(c *C) {
+	m := []struct {
+		comment     string
+		runYamlText string
+		err         string
+	}{
+		{
+			"missing main",
+			`
+			runtime: java
+			config_set:
+			  default:
+			    classpath:
+			      - /src
+			`,
+			"'main' must be provided",
+		},
+		{
+			"missing classpath",
+			`
+			runtime: java
+			config_set:
+			  default:
+			    main: demo.Main
+			`,
+			"'classpath' must be provided",
+		},
+		{
+			"inheritance overrides validation",
+			`
+			runtime: java
+			config_set:
+			  default:
+			    base: "some.package:its_config_set"
+			`,
+			"",
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare
+		cmdConfig, err := ParsePackageRunManifestData([]byte(FixIndent(args.runYamlText)))
+		testRuntime, _ := cmdConfig.selectConfigSetByName("default")
+
+		// This is what we're testing here.
+		err = testRuntime.Validate()
+
+		// Expectations.
+		if args.err == "" {
+			c.Check(err, IsNil)
+		} else {
+			c.Check(err, ErrorMatches, args.err)
+		}
+	}
+}
+
+func (*javaSuite) TestGetYamlTemplateIsComplete(c *C) {
+	// Prepare
+	testRuntime := javaRuntime{}
+
+	// This is what we're testing here.
+	template := testRuntime.GetYamlTemplate()
+
+	// Expectations.
+	c.Check(template, MatchesMultiline, "xms:")
+	c.Check(template, MatchesMultiline, "xmx:")
+	c.Check(template, MatchesMultiline, "classpath:")
+	c.Check(template, MatchesMultiline, "jvm_args:")
+	c.Check(template, MatchesMultiline, "main:")
+	c.Check(template, MatchesMultiline, "args:")
+	c.Check(template, MatchesMultiline, "env:")
+}
+
+func (*javaSuite) TestGetYamlTemplateIsValidYaml(c *C) {
+	// Prepare
+	testRuntime := javaRuntime{}
+	template := testRuntime.GetYamlTemplate()
+
+	// This is what we're testing here.
+	err := yaml.Unmarshal([]byte(template), &javaRuntime{})
+
+	// Expectations.
+	c.Assert(err, IsNil)
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -83,6 +83,26 @@ type CommonRuntime struct {
 	Base string            `yaml:"base"`
 }
 
+// setDefaultEnv sets default values for runtime's own environment.
+// Only non-existing keys are set and then a list of those is returned.
+func (r *CommonRuntime) setDefaultEnv(env map[string]string) []string {
+	if r.Env == nil {
+		r.Env = make(map[string]string, 15)
+	}
+
+	updated := make([]string, 15)
+	for key, value := range env {
+		if value == "" {
+			continue
+		}
+		if _, exists := r.Env[key]; !exists {
+			r.Env[key] = value
+			updated = append(updated, key)
+		}
+	}
+	return updated
+}
+
 func (r CommonRuntime) GetYamlTemplate() string {
 	return `
 # OPTIONAL


### PR DESCRIPTION
Current Java runtime is implemented in a very old fashion that relies on /etc/javamains file be present on the unikernel. Since this is now obsolete and brings issues since bootcmd cannot be set after the unikernel is built, we rewrite the runtime.

With this commit we first get rid of the problematic OnCollect function that was creating /etc/javamains file. With openjdk8-zulu-compact1 package the javamains is no longer needed. Then we reimplement the GetBootCmd function that now doesn't build the actual bootcmd on its own anymore but rather makes use of bootcmd provided by openjdk8-zulu-compact1 package (bootcmd inheritance). We also ensure that list of available arguments of "runtime: java" matches those of openjdk8-zulu-compact1 meta/run.yaml.

So with this commit we actually transform runtime into a thin wrapper of a specific package. User could easily use package directly, but the wrapper offers him some validation and nicer format of arguments.