### PR TITLE
Drop unneeded OnCollect function

### DIFF
--- a/cmd/package.go
+++ b/cmd/package.go
@@ -362,20 +362,13 @@ func CollectPackage(repo *util.Repo, packageDir string, pullMissing bool, custom
 			return fmt.Errorf("File %s has unsupported mode %v", path, info.Mode())
 		}
 	})
-
-	// Persist all boot commands into /run directory.
-	if err := allCmdConfigs.Persist(targetPath); err != nil {
-		return err
-	}
-
 	if err != nil {
 		return err
 	}
 
-	if genRuntime != nil {
-		if err := genRuntime.OnCollect(targetPath); err != nil {
-			return err
-		}
+	// Persist all boot commands into /run directory.
+	if err := allCmdConfigs.Persist(targetPath); err != nil {
+		return err
 	}
 
 	return nil

--- a/runtime/native.go
+++ b/runtime/native.go
@@ -42,9 +42,6 @@ func (conf nativeRuntime) GetBootCmd(cmdConfs map[string]*CmdConfig, env map[str
 	cmd := conf.BootCmd
 	return conf.CommonRuntime.BuildBootCmd(cmd, cmdConfs, env)
 }
-func (conf nativeRuntime) OnCollect(targetPath string) error {
-	return nil
-}
 func (conf nativeRuntime) GetYamlTemplate() string {
 	return `
 # REQUIRED

--- a/runtime/node.go
+++ b/runtime/node.go
@@ -44,9 +44,6 @@ func (conf nodeJsRuntime) GetBootCmd(cmdConfs map[string]*CmdConfig, env map[str
 	cmd := fmt.Sprintf("node %s", conf.Main)
 	return conf.CommonRuntime.BuildBootCmd(cmd, cmdConfs, env)
 }
-func (conf nodeJsRuntime) OnCollect(targetPath string) error {
-	return nil
-}
 func (conf nodeJsRuntime) GetYamlTemplate() string {
 	return `
 # REQUIRED

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -65,10 +65,6 @@ type Runtime interface {
 	// is this runtime used for, 50 chars
 	GetRuntimeDescription() string
 
-	// OnCollect is a callback to run when collecting package
-	// (accepts directroy path of the package)
-	OnCollect(string) error
-
 	// GetYamlTemplate provides a string containing yaml content with
 	// as much help text as possible.
 	// NOTE: provide only runtime-specific part of yaml, see runtime/node.go for example.


### PR DESCRIPTION
There was the "OnCollect()" function defined in Runtime interface that was meant to prepare additional files needed by selected run configuration. But using this function we actuall lock unikernel during `capstan package compose` to that specific boot command. In other words, config set can not be changed when invoking `capstan run` because no files can be changed at that time.

Luckily, it turns out that there was only Java package using the problemmatic "OnCollect()" function and that even Java can be used without it. With this commit we therefore simply remove the "OnCollect()" function, that only causes problems.
