### PR TITLE
Rewrite Node.js runtime to make use of config_set inheritance

### DIFF
--- a/Documentation/RuntimeNode.md
+++ b/Documentation/RuntimeNode.md
@@ -1,0 +1,69 @@
+# Runtime `node`
+This document describes how to write a valid `meta/run.yaml` configuration file
+for running **Node.js** application. Please note that you needn't require Node
+MPM package manually since Capstan will require require following package automatically:
+
+```
+- node-4.4.5
+```
+
+## Interactive node interpreter
+Following configuration can be used to run interactive Node.js interpreter inside OSv:
+
+```yaml
+# meta/run.yaml
+
+runtime: node
+
+config_set:
+  interpreter:
+    shell: true
+```
+
+Example:
+
+```bash
+$ capstan package compose demo
+$ capstan run demo --boot interpreter
+Command line will be set based on --boot parameter
+Created instance: demo
+Setting cmdline: runscript /run/interpreter
+OSv v0.24-434-gf4d1dfb
+eth0: 192.168.122.15
+> console.log("Hello World from Node.js interactive interpreter!")
+Hello World from Node.js interactive interpreter!
+undefined
+>
+```
+
+## Node.js script
+Following configuration can be used to run Node.js script inside OSv:
+
+```yaml
+# meta/run.yaml
+
+runtime: node
+
+config_set:
+  hello:
+    main: /greeting.js
+    args:
+      - "Johnny"
+```
+Note that /greeting.js script mentioned in the snippet above is a simple script that we've
+implemented for the sake of demo. It prints node arguments to the console and then
+exits.
+
+Example:
+
+```bash
+$ capstan package compose demo
+$ capstan run demo --boot hello
+Command line will be set based on --boot parameter
+Created instance: demo
+Setting cmdline: runscript /run/hello
+OSv v0.24-434-gf4d1dfb
+eth0: 192.168.122.15
+Hello to:
+- Johnny
+```

--- a/runtime/node.go
+++ b/runtime/node.go
@@ -9,11 +9,15 @@ package runtime
 
 import (
 	"fmt"
+	"strings"
 )
 
 type nodeJsRuntime struct {
 	CommonRuntime `yaml:"-,inline"`
-	Main          string `yaml:"main"`
+	NodeArgs      []string `yaml:"node_args"`
+	Main          string   `yaml:"main"`
+	Args          []string `yaml:"args"`
+	IsShell       bool     `yaml:"shell"` // run interactive node interpreter
 }
 
 //
@@ -30,7 +34,18 @@ func (conf nodeJsRuntime) GetDependencies() []string {
 	return []string{"node-4.4.5"}
 }
 func (conf nodeJsRuntime) Validate() error {
-	if conf.Base == "" {
+	if conf.Base != "" {
+		if conf.IsShell || len(conf.NodeArgs) > 0 || conf.Main != "" || len(conf.Args) > 0 {
+			return fmt.Errorf("incompatible arguments specified [shell,node_args,main,args] for custom 'base'")
+		}
+	} else if conf.IsShell {
+		if conf.Main != "" || len(conf.Args) > 0 {
+			return fmt.Errorf("incompatible arguments specified [main,args] for shell=true")
+		}
+		if conf.Env["MAIN"] != "" || conf.Env["ARGS"] != "" {
+			return fmt.Errorf("incompatible 'env' keys specified [MAIN,ARGS] for shell=true")
+		}
+	} else {
 		if conf.Main == "" {
 			return fmt.Errorf("'main' must be provided")
 		}
@@ -39,8 +54,21 @@ func (conf nodeJsRuntime) Validate() error {
 	return conf.CommonRuntime.Validate()
 }
 func (conf nodeJsRuntime) GetBootCmd(cmdConfs map[string]*CmdConfig, env map[string]string) (string, error) {
-	cmd := fmt.Sprintf("node %s", conf.Main)
-	return conf.CommonRuntime.BuildBootCmd(cmd, cmdConfs, env)
+	conf.Base = "node-4.4.5:node"
+	conf.setDefaultEnv(map[string]string{
+		"NODE_ARGS": conf.concatNodeArgs(),
+	})
+
+	if conf.IsShell {
+		conf.Env["MAIN"] = ""
+		conf.Env["ARGS"] = ""
+	} else {
+		conf.setDefaultEnv(map[string]string{
+			"MAIN": conf.Main,
+			"ARGS": strings.Join(conf.Args, " "),
+		})
+	}
+	return conf.CommonRuntime.BuildBootCmd("", cmdConfs, env)
 }
 func (conf nodeJsRuntime) GetYamlTemplate() string {
 	return `
@@ -49,5 +77,39 @@ func (conf nodeJsRuntime) GetYamlTemplate() string {
 # Note that package root will correspond to filesystem root (/) in OSv image.
 # Example value: /server.js
 main: <filepath>
+
+# OPTIONAL
+# A list of Node.js args.
+# Example value: node_args:
+#                   - --require module1
+node_args:
+   - <list>
+
+# OPTIONAL
+# A list of command line args used by the application.
+# Example value: args:
+#                   - argument1
+#                   - argument2
+args:
+   - <list>
+
+# OPTIONAL
+# Set to true to only run node shell. Note that "main" and "args" will then be ignored.
+shell: false
 ` + conf.CommonRuntime.GetYamlTemplate()
+}
+
+//
+// Utility
+//
+
+func (conf nodeJsRuntime) concatNodeArgs() string {
+	if len(conf.NodeArgs) > 0 {
+		return strings.Join(conf.NodeArgs, " ")
+	} else {
+		// This is a workaround since runscript is currently unable to
+		// handle empty environment variable as a parameter. So we set
+		// dummy value unless user provided some actual value.
+		return "--"
+	}
 }

--- a/runtime/node_test.go
+++ b/runtime/node_test.go
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2017 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package runtime
+
+import (
+	. "github.com/mikelangelo-project/capstan/testing"
+	. "gopkg.in/check.v1"
+	yaml "gopkg.in/yaml.v1"
+)
+
+type nodeSuite struct {
+}
+
+var _ = Suite(&nodeSuite{})
+
+func (*nodeSuite) TestGetBootCmd(c *C) {
+	// Simulate node-4.4.5's meta/run.yaml being parsed.
+	cmdConfs := map[string]*CmdConfig{
+		"node-4.4.5": &CmdConfig{
+			RuntimeType:      Native,
+			ConfigSetDefault: "node",
+			ConfigSets: map[string]Runtime{
+				"node": nativeRuntime{
+					BootCmd: "/node.so",
+					CommonRuntime: CommonRuntime{
+						Env: map[string]string{
+							"NODE_ARGS": "--",
+							"MAIN":      "/mymain.js",
+							"ARGS":      "",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	m := []struct {
+		comment      string
+		runYamlText  string
+		expectedBoot string
+		expectedEnv  []string
+	}{
+		{
+			"simple",
+			`
+			runtime: node
+			config_set:
+			  default:
+			    main: /server.js
+			`,
+			"/node.so", []string{
+				"--env=NODE_ARGS?=--",
+				"--env=MAIN?=/server.js",
+				"--env=ARGS?=",
+			},
+		},
+		{
+			"node args",
+			`
+			runtime: node
+			config_set:
+			  default:
+			    main: /server.js
+			    node_args:
+			        - --version
+			`,
+			"/node.so", []string{
+				"--env=NODE_ARGS?=--version",
+				"--env=MAIN?=/server.js",
+				"--env=ARGS?=",
+			},
+		},
+		{
+			"args",
+			`
+			runtime: node
+			config_set:
+			  default:
+			    main: /server.js
+			    args:
+			        - localhost
+			        - 8000
+			`,
+			"/node.so", []string{
+				"--env=NODE_ARGS?=--",
+				"--env=MAIN?=/server.js",
+				"--env=ARGS?=localhost 8000",
+			},
+		},
+		{
+			"shell",
+			`
+			runtime: node
+			config_set:
+			  default:
+			    shell: true
+			`,
+			"/node.so", []string{
+				"--env=NODE_ARGS?=--",
+				"--env=MAIN?=",
+				"--env=ARGS?=",
+			},
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare
+		cmdConfig, err := ParsePackageRunManifestData([]byte(FixIndent(args.runYamlText)))
+		testRuntime, _ := cmdConfig.selectConfigSetByName("default")
+
+		// This is what we're testing here.
+		boot, err := testRuntime.GetBootCmd(cmdConfs, map[string]string{})
+
+		// Expectations.
+		c.Assert(err, IsNil)
+		c.Check(boot, BootCmdEquals, args.expectedBoot, args.expectedEnv)
+	}
+}
+
+func (*nodeSuite) TestValidate(c *C) {
+	m := []struct {
+		comment     string
+		runYamlText string
+		err         string
+	}{
+		{
+			"incompatible with 'base' - shell",
+			`
+			runtime: node
+			config_set:
+			  default:
+			    base: "foo:bar"
+			    shell: true
+			`,
+			"incompatible arguments specified \\[shell,node_args,main,args\\] for custom 'base'",
+		},
+		{
+			"incompatible with 'base' - node_args",
+			`
+			runtime: node
+			config_set:
+			  default:
+			    base: "foo:bar"
+			    node_args:
+			      - foo.bar
+			`,
+			"incompatible arguments specified \\[shell,node_args,main,args\\] for custom 'base'",
+		},
+		{
+			"incompatible with 'base' - main",
+			`
+			runtime: node
+			config_set:
+			  default:
+			    base: "foo:bar"
+			    main: foo.bar
+			`,
+			"incompatible arguments specified \\[shell,node_args,main,args\\] for custom 'base'",
+		},
+		{
+			"incompatible with 'base' - args",
+			`
+			runtime: node
+			config_set:
+			  default:
+			    base: "foo:bar"
+			    args:
+			      - foo.bar
+			`,
+			"incompatible arguments specified \\[shell,node_args,main,args\\] for custom 'base'",
+		},
+		{
+			"incompatible with 'shell' - main",
+			`
+			runtime: node
+			config_set:
+			  default:
+			    shell: true
+			    main: /script.js
+			`,
+			"incompatible arguments specified \\[main,args\\] for shell=true",
+		},
+		{
+			"incompatible with 'shell' - args",
+			`
+			runtime: node
+			config_set:
+			  default:
+			    shell: true
+			    args:
+			      - foo.bar
+			`,
+			"incompatible arguments specified \\[main,args\\] for shell=true",
+		},
+		{
+			"incompatible with 'shell' - env.MAIN",
+			`
+			runtime: node
+			config_set:
+			  default:
+			    shell: true
+			    env:
+			      MAIN: foo
+			`,
+			"incompatible 'env' keys specified \\[MAIN,ARGS\\] for shell=true",
+		},
+		{
+			"incompatible with 'shell' - env.ARGS",
+			`
+			runtime: node
+			config_set:
+			  default:
+			    shell: true
+			    env:
+			      ARGS: foo.bar
+			`,
+			"incompatible 'env' keys specified \\[MAIN,ARGS\\] for shell=true",
+		},
+		{
+			"missing main",
+			`
+			runtime: node
+			config_set:
+			  default:
+			`,
+			"'main' must be provided",
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare
+		cmdConfig, err := ParsePackageRunManifestData([]byte(FixIndent(args.runYamlText)))
+		testRuntime, _ := cmdConfig.selectConfigSetByName("default")
+
+		// This is what we're testing here.
+		err = testRuntime.Validate()
+
+		// Expectations.
+		if args.err == "" {
+			c.Check(err, IsNil)
+		} else {
+			c.Check(err, ErrorMatches, args.err)
+		}
+	}
+}
+
+func (*nodeSuite) TestGetYamlTemplateIsComplete(c *C) {
+	// Prepare
+	testRuntime := nodeJsRuntime{}
+
+	// This is what we're testing here.
+	template := testRuntime.GetYamlTemplate()
+
+	// Expectations.
+	c.Check(template, MatchesMultiline, "node_args:")
+	c.Check(template, MatchesMultiline, "main:")
+	c.Check(template, MatchesMultiline, "args:")
+	c.Check(template, MatchesMultiline, "env:")
+}
+
+func (*nodeSuite) TestGetYamlTemplateIsValidYaml(c *C) {
+	// Prepare
+	testRuntime := nodeJsRuntime{}
+	template := testRuntime.GetYamlTemplate()
+
+	// This is what we're testing here.
+	err := yaml.Unmarshal([]byte(template), &nodeJsRuntime{})
+
+	// Expectations.
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
Now that node-4.4.5 package contains `meta/run.yaml`, we are able to use it also in case of "runtime: node". We ensure that list of available arguments of "runtime: node" matches those of node-4.4.5 package.