### PR TITLE
Add "runtime: python" that wrapps python-2.7 package

### DIFF
--- a/runtime/python.go
+++ b/runtime/python.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2017 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package runtime
+
+import "strings"
+
+type pythonRuntime struct {
+	CommonRuntime `yaml:"-,inline"`
+	PythonArgs    []string `yaml:"python_args"`
+	Main          string   `yaml:"main"`
+	Args          []string `yaml:"args"`
+}
+
+//
+// Interface implementation
+//
+
+func (conf pythonRuntime) GetRuntimeName() string {
+	return string(Python)
+}
+func (conf pythonRuntime) GetRuntimeDescription() string {
+	return "Run Python 2.7 application"
+}
+func (conf pythonRuntime) GetDependencies() []string {
+	return []string{"python-2.7"}
+}
+func (conf pythonRuntime) Validate() error {
+	inherit := conf.Base != ""
+	return conf.CommonRuntime.Validate(inherit)
+}
+func (conf pythonRuntime) GetBootCmd(cmdConfs map[string]*CmdConfig, env map[string]string) (string, error) {
+	conf.Base = "python-2.7:python"
+	conf.setDefaultEnv(map[string]string{
+		"PYTHON_ARGS": conf.concatPythonArgs(),
+		"MAIN":        conf.Main,
+		"ARGS":        strings.Join(conf.Args, " "),
+	})
+	return conf.CommonRuntime.BuildBootCmd("", cmdConfs, env)
+}
+func (conf pythonRuntime) GetYamlTemplate() string {
+	return `
+# REQUIRED
+# Filepath of the Python script.
+# Note that package root will correspond to filesystem root (/) in OSv image.
+# Example value: /hello-world.py
+main: <filepath>
+
+# OPTIONAL
+# A list of Python args.
+# Example value: node_args:
+#                   - -O
+python_args:
+   - <list>
+
+# OPTIONAL
+# A list of command line args used by the application.
+# Example value: args:
+#                   - argument1
+#                   - argument2
+args:
+   - <list>
+` + conf.CommonRuntime.GetYamlTemplate()
+}
+
+//
+// Utility
+//
+
+func (conf pythonRuntime) concatPythonArgs() string {
+	if len(conf.PythonArgs) > 0 {
+		return strings.Join(conf.PythonArgs, " ")
+	} else {
+		// This is a workaround since runscript is currently unable to
+		// handle empty environment variable as a parameter. So we set
+		// dummy value unless user provided some actual value.
+		return "-O"
+	}
+}

--- a/runtime/python_test.go
+++ b/runtime/python_test.go
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2017 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package runtime
+
+import (
+	. "github.com/mikelangelo-project/capstan/testing"
+	. "gopkg.in/check.v1"
+	yaml "gopkg.in/yaml.v1"
+)
+
+type pythonSuite struct {
+}
+
+var _ = Suite(&pythonSuite{})
+
+func (*pythonSuite) TestGetBootCmd(c *C) {
+	// Simulate node-4.4.5's meta/run.yaml being parsed.
+	cmdConfs := map[string]*CmdConfig{
+		"python-2.7": &CmdConfig{
+			RuntimeType:      Native,
+			ConfigSetDefault: "python",
+			ConfigSets: map[string]Runtime{
+				"python": nativeRuntime{
+					BootCmd: "/python.so",
+					CommonRuntime: CommonRuntime{
+						Env: map[string]string{
+							"PYTHON_ARGS": "-O",
+							"MAIN":        "-",
+							"ARGS":        "",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	m := []struct {
+		comment      string
+		runYamlText  string
+		expectedBoot string
+		expectedEnv  []string
+	}{
+		{
+			"simple",
+			`
+			runtime: python
+			config_set:
+			  default:
+			    main: /script.py
+			`,
+			"/python.so", []string{
+				"--env=PYTHON_ARGS?=-O",
+				"--env=MAIN?=/script.py",
+				"--env=ARGS?=",
+			},
+		},
+		{
+			"python args",
+			`
+			runtime: python
+			config_set:
+			  default:
+			    main: /script.py
+			    python_args:
+			        - --version
+			`,
+			"/python.so", []string{
+				"--env=PYTHON_ARGS?=--version",
+				"--env=MAIN?=/script.py",
+				"--env=ARGS?=",
+			},
+		},
+		{
+			"args",
+			`
+			runtime: python
+			config_set:
+			  default:
+			    main: /script.py
+			    args:
+			        - localhost
+			        - 8000
+			`,
+			"/python.so", []string{
+				"--env=PYTHON_ARGS?=-O",
+				"--env=MAIN?=/script.py",
+				"--env=ARGS?=localhost 8000",
+			},
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare
+		cmdConfig, err := ParsePackageRunManifestData([]byte(FixIndent(args.runYamlText)))
+		testRuntime, _ := cmdConfig.selectConfigSetByName("default")
+
+		// This is what we're testing here.
+		boot, err := testRuntime.GetBootCmd(cmdConfs, map[string]string{})
+
+		// Expectations.
+		c.Assert(err, IsNil)
+		c.Check(boot, BootCmdEquals, args.expectedBoot, args.expectedEnv)
+	}
+}
+
+func (*pythonSuite) TestGetYamlTemplateIsComplete(c *C) {
+	// Prepare
+	testRuntime := pythonRuntime{}
+
+	// This is what we're testing here.
+	template := testRuntime.GetYamlTemplate()
+
+	// Expectations.
+	c.Check(template, MatchesMultiline, "python_args:")
+	c.Check(template, MatchesMultiline, "main:")
+	c.Check(template, MatchesMultiline, "args:")
+	c.Check(template, MatchesMultiline, "env:")
+}
+
+func (*pythonSuite) TestGetYamlTemplateIsValidYaml(c *C) {
+	// Prepare
+	testRuntime := pythonRuntime{}
+	template := testRuntime.GetYamlTemplate()
+
+	// This is what we're testing here.
+	err := yaml.Unmarshal([]byte(template), &pythonRuntime{})
+
+	// Expectations.
+	c.Assert(err, IsNil)
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -21,6 +21,7 @@ const (
 	Native RuntimeType = "native"
 	NodeJS RuntimeType = "node"
 	Java   RuntimeType = "java"
+	Python RuntimeType = "python"
 )
 
 var SupportedRuntimes []RuntimeType = []RuntimeType{
@@ -187,6 +188,8 @@ func PickRuntime(runtimeName RuntimeType) (Runtime, error) {
 		return &nodeJsRuntime{}, nil
 	case Java:
 		return &javaRuntime{}, nil
+	case Python:
+		return &pythonRuntime{}, nil
 	}
 
 	return nil, fmt.Errorf("Unknown runtime: '%s'\n", runtimeName)


### PR DESCRIPTION
With this commit we implement yet another runtime, python. It's possible to either run Python shell or Python script.