### PR TITLE
Let MPM package remember creation time

### DIFF
--- a/cmd/package.go
+++ b/cmd/package.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/mikelangelo-project/capstan/core"
 	"github.com/mikelangelo-project/capstan/runtime"
@@ -25,7 +26,10 @@ import (
 )
 
 func InitPackage(packagePath string, p *core.Package) error {
-	// We have to create hte package directory and it's metadata directory.
+	// Remember when the package was initialized.
+	p.Created = core.YamlTime{time.Now()}
+
+	// We have to create the package directory and it's metadata directory.
 	metaPath := filepath.Join(packagePath, "meta")
 
 	fmt.Printf("Initializing package in %s\n", metaPath)

--- a/core/package.go
+++ b/core/package.go
@@ -9,22 +9,20 @@ package core
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
-	"time"
+
+	"gopkg.in/yaml.v2"
 )
 
 type Package struct {
 	Name    string
 	Title   string
-	Author  string            "author,omitempty"
-	Version string            "version,omitempty"
-	Require []string          "require,omitempty"
-	Binary  map[string]string "binary,omitempty"
-	// ModTime is currently used only for setting the modification time of local
-	// packages. It is ignored by the YAML parser.
-	ModTime time.Time "-"
+	Author  string            `yaml:"author,omitempty"`
+	Version string            `yaml:"version,omitempty"`
+	Require []string          `yaml:"require,omitempty"`
+	Binary  map[string]string `yaml:"binary,omitempty"`
+	Created YamlTime          `yaml:"created"`
 }
 
 func (p *Package) Parse(data []byte) error {
@@ -70,5 +68,5 @@ func ParsePackageManifest(manifestFile string) (Package, error) {
 }
 
 func (p *Package) String() string {
-	return fmt.Sprintf("%-50s %-50s %-25s %-15s", p.Name, p.Title, p.Version, p.ModTime.Format(time.RFC3339))
+	return fmt.Sprintf("%-50s %-50s %-25s %-15s", p.Name, p.Title, p.Version, p.Created)
 }

--- a/core/yaml.go
+++ b/core/yaml.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2017 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package core
+
+import (
+	// "fmt"
+	"time"
+)
+
+const FRIENDLY_TIME_F = "2006-01-02 15:04"
+
+type YamlTime struct {
+	Time interface{}
+}
+
+// MarshalYAML transforms YamlTime object into a RFC3339 string.
+func (t YamlTime) MarshalYAML() (interface{}, error) {
+	v, _ := t.Time.(time.Time)
+	return v.Format(time.RFC3339), nil
+}
+
+// UnmarshalYAML parses string into YamlTime object. Following formats
+// are supported: RFC3339, FRIENDLY_TIME_F
+// If time string is invalid, a special YamlTime is created that is then
+// marked as '?' when printed as string.
+func (t *YamlTime) UnmarshalYAML(unmarshaller func(interface{}) error) error {
+	unmarshaller(&t.Time)
+	s, _ := t.Time.(string)
+
+	if v, err := time.Parse(time.RFC3339, s); err == nil {
+		t.Time = v
+	} else if v, err := time.Parse(FRIENDLY_TIME_F, s); err == nil {
+		t.Time = v
+	} else {
+		t.Time = nil
+	}
+
+	return nil
+}
+
+func (t YamlTime) String() string {
+	if v, ok := t.Time.(time.Time); ok {
+		return v.Format(FRIENDLY_TIME_F)
+	} else {
+		return "?"
+	}
+}

--- a/core/yaml_test.go
+++ b/core/yaml_test.go
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2017 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package core
+
+import (
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type yamlSuite struct {
+}
+
+var _ = Suite(&yamlSuite{})
+
+type yamlWithTimeFieldStruct struct {
+	Created YamlTime `yaml:"created"`
+}
+
+func (*yamlSuite) TestYamlTimeFieldMarshall(c *C) {
+
+	m := []struct {
+		comment  string
+		created  string
+		expected string
+	}{
+		{
+			"simple",
+			"2017-09-14T18:08:16+02:00",
+			"created: 2017-09-14T18:08:16+02:00",
+		},
+		{
+			"miliseconds should not get marshalled",
+			"2017-09-14T18:08:16.123456789+02:00",
+			"created: 2017-09-14T18:08:16+02:00",
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare
+		t, _ := time.Parse(time.RFC3339, args.created)
+		obj := yamlWithTimeFieldStruct{
+			Created: YamlTime{t},
+		}
+
+		// This is what we're testing here.
+		data, err := yaml.Marshal(&obj)
+
+		// Expectations.
+		c.Assert(err, IsNil)
+		c.Check(string(data), Equals, args.expected+"\n")
+	}
+}
+
+func (*yamlSuite) TestYamlTimeFieldUnmarshall(c *C) {
+
+	m := []struct {
+		comment  string
+		yamltext string
+		expected string
+	}{
+		{
+			"RFC3339",
+			"created: 2017-09-14T18:08:16+02:00",
+			"2017-09-14 18:08",
+		},
+		{
+			"RFC3339 with miliseconds",
+			"created: 2017-09-14T18:08:16.123456789+02:00",
+			"2017-09-14 18:08",
+		},
+		{
+			"friendly",
+			"created: 2017-09-14 18:08",
+			"2017-09-14 18:08",
+		},
+		{
+			"empty",
+			"created: ",
+			"?",
+		},
+		{
+			"missing",
+			"",
+			"?",
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare
+		obj := yamlWithTimeFieldStruct{}
+
+		// This is what we're testing here.
+		err := yaml.Unmarshal([]byte(args.yamltext), &obj)
+
+		// Expectations.
+		c.Assert(err, IsNil)
+		c.Check(obj.Created.String(), Equals, args.expected)
+	}
+}

--- a/testing/common.go
+++ b/testing/common.go
@@ -11,9 +11,12 @@ import (
 	"strings"
 )
 
+const TIMESTAMP_REGEX string = `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{2}:\d{2})?[Zz]?`
+
 // FixIndent moves the inline yaml content to the very left.
 // This way we are able to write inline yaml content that is
 // nicely aligned with other code.
 func FixIndent(s string) string {
+	s = strings.TrimSpace(s) + "\n"
 	return strings.Replace(s, "\t", "", -1)
 }

--- a/util/repository.go
+++ b/util/repository.go
@@ -251,9 +251,6 @@ func (r *Repo) ListPackages() {
 				continue
 			}
 
-			// Set the modification time to the one of the package manifest file.
-			pkg.ModTime = p.ModTime()
-
 			fmt.Println(pkg.String())
 		}
 	}


### PR DESCRIPTION
Now that capstan-packages building platform is available we come to situation when we start wondering whether we have the latest MPM packages in our local repository.

With this commit we replace field ModTime with Create where we store timestamp of the moment when `capstan package init` was called. This way user is able to differentiate between multiple builds of the same version of the package. Mostly useful for debugging.