### PR TITLE
Remove boolean parameter from Validate(inherit) function

### DIFF
--- a/runtime/java.go
+++ b/runtime/java.go
@@ -36,9 +36,7 @@ func (conf javaRuntime) GetDependencies() []string {
 	return []string{"openjdk8-zulu-compact1"}
 }
 func (conf javaRuntime) Validate() error {
-	inherit := conf.Base != ""
-
-	if !inherit {
+	if conf.Base == "" {
 		if conf.Main == "" {
 			return fmt.Errorf("'main' must be provided")
 		}
@@ -48,7 +46,7 @@ func (conf javaRuntime) Validate() error {
 		}
 	}
 
-	return conf.CommonRuntime.Validate(inherit)
+	return conf.CommonRuntime.Validate()
 }
 func (conf javaRuntime) GetBootCmd(cmdConfs map[string]*CmdConfig, env map[string]string) (string, error) {
 	if conf.Base == "" { // Allow user to use e.g. "openjdk7:java" package instead default one.

--- a/runtime/native.go
+++ b/runtime/native.go
@@ -28,15 +28,13 @@ func (conf nativeRuntime) GetDependencies() []string {
 	return []string{}
 }
 func (conf nativeRuntime) Validate() error {
-	inherit := conf.Base != ""
-
-	if !inherit {
+	if conf.Base == "" {
 		if conf.BootCmd == "" {
 			return fmt.Errorf("'bootcmd' must be provided")
 		}
 	}
 
-	return conf.CommonRuntime.Validate(inherit)
+	return conf.CommonRuntime.Validate()
 }
 func (conf nativeRuntime) GetBootCmd(cmdConfs map[string]*CmdConfig, env map[string]string) (string, error) {
 	cmd := conf.BootCmd

--- a/runtime/node.go
+++ b/runtime/node.go
@@ -30,15 +30,13 @@ func (conf nodeJsRuntime) GetDependencies() []string {
 	return []string{"node-4.4.5"}
 }
 func (conf nodeJsRuntime) Validate() error {
-	inherit := conf.Base != ""
-
-	if !inherit {
+	if conf.Base == "" {
 		if conf.Main == "" {
 			return fmt.Errorf("'main' must be provided")
 		}
 	}
 
-	return conf.CommonRuntime.Validate(inherit)
+	return conf.CommonRuntime.Validate()
 }
 func (conf nodeJsRuntime) GetBootCmd(cmdConfs map[string]*CmdConfig, env map[string]string) (string, error) {
 	cmd := fmt.Sprintf("node %s", conf.Main)

--- a/runtime/python.go
+++ b/runtime/python.go
@@ -30,8 +30,7 @@ func (conf pythonRuntime) GetDependencies() []string {
 	return []string{"python-2.7"}
 }
 func (conf pythonRuntime) Validate() error {
-	inherit := conf.Base != ""
-	return conf.CommonRuntime.Validate(inherit)
+	return conf.CommonRuntime.Validate()
 }
 func (conf pythonRuntime) GetBootCmd(cmdConfs map[string]*CmdConfig, env map[string]string) (string, error) {
 	conf.Base = "python-2.7:python"

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -121,17 +121,15 @@ base: "<package-name>:<config_set>"
 `
 }
 
-func (r CommonRuntime) Validate(inherit bool) error {
+func (r CommonRuntime) Validate() error {
 	for k, v := range r.Env {
 		if strings.Contains(k, " ") || strings.Contains(v, " ") {
 			return fmt.Errorf("spaces not allowed in env key/value: '%s':'%s'", k, v)
 		}
 	}
 
-	if inherit {
-		if r.Base == "" {
-			return fmt.Errorf("'base' must be provided")
-		}
+	// Common validation in case of bootcmd inheritance
+	if r.Base != "" {
 		if !strings.Contains(r.Base, ":") {
 			return fmt.Errorf("'base' must be in format <pkg_name>:<config_set>")
 		}


### PR DESCRIPTION
The boolean parameter 'inherit' was predicted for Validate function in Runtime interface, but that boolean can be calculated at any time from struct attributes. With this commit we remove it.