### PR TITLE
Marshall empty timestamp into N/A  instead of zero timestamp

### DIFF
--- a/core/yaml.go
+++ b/core/yaml.go
@@ -8,7 +8,6 @@
 package core
 
 import (
-	// "fmt"
 	"time"
 )
 
@@ -20,8 +19,11 @@ type YamlTime struct {
 
 // MarshalYAML transforms YamlTime object into a RFC3339 string.
 func (t YamlTime) MarshalYAML() (interface{}, error) {
-	v, _ := t.Time.(time.Time)
-	return v.Format(time.RFC3339), nil
+	if v, ok := t.Time.(time.Time); ok {
+		return v.Format(time.RFC3339), nil
+	} else {
+		return "N/A", nil
+	}
 }
 
 // UnmarshalYAML parses string into YamlTime object. Following formats
@@ -47,6 +49,6 @@ func (t YamlTime) String() string {
 	if v, ok := t.Time.(time.Time); ok {
 		return v.Format(FRIENDLY_TIME_F)
 	} else {
-		return "?"
+		return "N/A"
 	}
 }

--- a/core/yaml_test.go
+++ b/core/yaml_test.go
@@ -44,14 +44,22 @@ func (*yamlSuite) TestYamlTimeFieldMarshall(c *C) {
 			"2017-09-14T18:08:16.123456789+02:00",
 			"created: 2017-09-14T18:08:16+02:00",
 		},
+		{
+			"empty",
+			"",
+			"created: N/A",
+		},
 	}
 	for i, args := range m {
 		c.Logf("CASE #%d: %s", i, args.comment)
 
 		// Prepare
-		t, _ := time.Parse(time.RFC3339, args.created)
+		yamlTime := YamlTime{}
+		if t, _ := time.Parse(time.RFC3339, args.created); args.created != "" {
+			yamlTime.Time = t
+		}
 		obj := yamlWithTimeFieldStruct{
-			Created: YamlTime{t},
+			Created: yamlTime,
 		}
 
 		// This is what we're testing here.
@@ -88,12 +96,12 @@ func (*yamlSuite) TestYamlTimeFieldUnmarshall(c *C) {
 		{
 			"empty",
 			"created: ",
-			"?",
+			"N/A",
 		},
 		{
 			"missing",
 			"",
-			"?",
+			"N/A",
 		},
 	}
 	for i, args := range m {


### PR DESCRIPTION
Currently, if we are marshalling a package with nil value for 'created' attribute, a zero timestamp gets written:

```
created: 0001-01-01 00:00
```

which is wrong. With this commit we rather marshall nil value into a N/A:

```
created: N/A
```

so that unmarshalling results into a nil date again, and not the zero one.