### PR TITLE
Platform attribute

### DIFF
--- a/capstan.go
+++ b/capstan.go
@@ -343,6 +343,7 @@ func main() {
 						cli.StringFlag{Name: "version,v", Usage: "package version"},
 						cli.StringSliceFlag{Name: "require", Usage: "specify package dependency"},
 						cli.StringFlag{Name: "runtime", Usage: "runtime to stub package for. Use 'capstan runtime list' to list all"},
+						cli.StringFlag{Name: "p, platform", Usage: "platform where package was built on"},
 					},
 					Action: func(c *cli.Context) error {
 						if len(c.Args()) > 1 {
@@ -374,11 +375,12 @@ func main() {
 						// Initialise the package structure. The version may be empty as it is not
 						// mandatory field.
 						p := &core.Package{
-							Name:    c.String("name"),
-							Title:   c.String("title"),
-							Author:  c.String("author"),
-							Version: c.String("version"),
-							Require: c.StringSlice("require"),
+							Name:     c.String("name"),
+							Title:    c.String("title"),
+							Author:   c.String("author"),
+							Version:  c.String("version"),
+							Require:  c.StringSlice("require"),
+							Platform: c.String("platform"),
 						}
 
 						// Init package
@@ -488,7 +490,7 @@ func main() {
 					Action: func(c *cli.Context) error {
 						repo := util.NewRepo(c.GlobalString("u"))
 
-						repo.ListPackages()
+						fmt.Print(repo.ListPackages())
 
 						return nil
 					},

--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -169,6 +169,22 @@ func (s *suite) TestInitPackage(c *C) {
 				created: {TIMESTAMP}
 			`,
 		},
+		{
+			"with platform",
+			core.Package{
+				Name:     "name",
+				Title:    "title",
+				Author:   "author",
+				Platform: "Ubuntu-14.04",
+			},
+			`
+				name: name
+				title: title
+				author: author
+				created: {TIMESTAMP}
+				platform: Ubuntu-14.04
+			`,
+		},
 	}
 	for i, args := range m {
 		c.Logf("CASE #%d: %s", i, args.comment)

--- a/core/package.go
+++ b/core/package.go
@@ -11,18 +11,20 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
 
 type Package struct {
-	Name    string
-	Title   string
-	Author  string            `yaml:"author,omitempty"`
-	Version string            `yaml:"version,omitempty"`
-	Require []string          `yaml:"require,omitempty"`
-	Binary  map[string]string `yaml:"binary,omitempty"`
-	Created YamlTime          `yaml:"created"`
+	Name     string
+	Title    string
+	Author   string            `yaml:"author,omitempty"`
+	Version  string            `yaml:"version,omitempty"`
+	Require  []string          `yaml:"require,omitempty"`
+	Binary   map[string]string `yaml:"binary,omitempty"`
+	Created  YamlTime          `yaml:"created"`
+	Platform string            `yaml:"platform,omitempty"`
 }
 
 func (p *Package) Parse(data []byte) error {
@@ -68,5 +70,6 @@ func ParsePackageManifest(manifestFile string) (Package, error) {
 }
 
 func (p *Package) String() string {
-	return fmt.Sprintf("%-50s %-50s %-25s %-15s", p.Name, p.Title, p.Version, p.Created)
+	res := fmt.Sprintf("%-50s %-50s %-15s %-20s %-15s", p.Name, p.Title, p.Version, p.Created, p.Platform)
+	return strings.TrimSpace(res)
 }

--- a/util/repository.go
+++ b/util/repository.go
@@ -239,8 +239,8 @@ func (r *Repo) ListImages() {
 	}
 }
 
-func (r *Repo) ListPackages() {
-	fmt.Println(FileInfoHeader())
+func (r *Repo) ListPackages() string {
+	res := fmt.Sprintln(FileInfoHeader())
 	packages, _ := ioutil.ReadDir(r.PackagesPath())
 	for _, p := range packages {
 		if filepath.Ext(p.Name()) == ".yaml" {
@@ -251,9 +251,10 @@ func (r *Repo) ListPackages() {
 				continue
 			}
 
-			fmt.Println(pkg.String())
+			res += fmt.Sprintln(pkg.String())
 		}
 	}
+	return res
 }
 
 func (r *Repo) DefaultImage() string {

--- a/util/repository_test.go
+++ b/util/repository_test.go
@@ -9,9 +9,13 @@
 package util_test
 
 import (
-	"github.com/mikelangelo-project/capstan/util"
-	. "gopkg.in/check.v1"
 	"path/filepath"
+
+	"github.com/mikelangelo-project/capstan/cmd"
+	"github.com/mikelangelo-project/capstan/util"
+
+	. "github.com/mikelangelo-project/capstan/testing"
+	. "gopkg.in/check.v1"
 )
 
 type suite struct {
@@ -20,16 +24,102 @@ type suite struct {
 
 func (s *suite) SetUpTest(c *C) {
 	s.repo = util.NewRepo(util.DefaultRepositoryUrl)
+	s.repo.Path = c.MkDir()
 }
 
 var _ = Suite(&suite{})
 
 func (s *suite) TestImagePath(c *C) {
 	path := s.repo.ImagePath("qemu", "valid")
-	c.Assert(path, Equals, filepath.Join(util.HomePath(), ".capstan", "repository", "valid", "valid.qemu"))
+	c.Assert(path, Equals, filepath.Join(s.repo.Path, "repository", "valid", "valid.qemu"))
 }
 
 func (s *suite) TestPackagePath(c *C) {
 	path := s.repo.PackagePath("package")
-	c.Assert(path, Equals, filepath.Join(util.HomePath(), ".capstan", "packages", "package.mpm"))
+	c.Assert(path, Equals, filepath.Join(s.repo.Path, "packages", "package.mpm"))
+}
+
+func (s *suite) TestPackageList(c *C) {
+	m := []struct {
+		comment  string
+		pkgYaml  string
+		expected string
+	}{
+		{
+			"simplest case",
+			`
+				name: name
+				title: description
+				author: author
+			`,
+			`
+				Name {47}Description {40}Version {9}Created {14}Platform
+				name {47}description {40}        {9}N/A
+			`,
+		},
+		{
+			"with version",
+			`
+				name: name
+				title: description
+				author: author
+				version: 0.1
+			`,
+			`
+				Name {47}Description {40}Version {9}Created {14}Platform
+				name {47}description {40}0.1     {9}N/A
+			`,
+		},
+		{
+			"with created",
+			`
+				name: name
+				title: description
+				author: author
+				created: 2017-07-31 14:49
+			`,
+			`
+				Name {47}Description {40}Version {9}Created          {5}Platform
+				name {47}description {40}        {9}2017-07-31 14:49
+			`,
+		},
+		{
+			"with platform",
+			`
+				name: name
+				title: description
+				author: author
+				platform: Ubuntu-14.04
+			`,
+			`
+				Name {47}Description {40}Version {9}Created {14}Platform
+				name {47}description {40}        {9}N/A     {14}Ubuntu-14.04
+			`,
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare.
+		files := map[string]string{
+			"meta/package.yaml": FixIndent(args.pkgYaml),
+		}
+		s.importPkg(files, c)
+
+		// This is what we're testing here.
+		txt := s.repo.ListPackages()
+
+		// Expectations.
+		c.Check(txt, MatchesMultiline, FixIndent(args.expected))
+	}
+}
+
+//
+// Utility
+//
+
+func (s *suite) importPkg(files map[string]string, c *C) {
+	tmpDir := c.MkDir()
+	PrepareFiles(tmpDir, files)
+	cmd.ImportPackage(s.repo, tmpDir)
 }

--- a/util/s3_repository.go
+++ b/util/s3_repository.go
@@ -11,15 +11,16 @@ import (
 	"compress/gzip"
 	"encoding/xml"
 	"fmt"
-	"github.com/cheggaaa/pb"
-	"github.com/mikelangelo-project/capstan/core"
-	"gopkg.in/yaml.v1"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/cheggaaa/pb"
+	"github.com/mikelangelo-project/capstan/core"
+	"gopkg.in/yaml.v1"
 )
 
 type FileInfo struct {
@@ -46,11 +47,12 @@ type FilesInfo struct {
 }
 
 func FileInfoHeader() string {
-	return fmt.Sprintf("%-50s %-50s %-25s %-15s", "Name", "Description", "Version", "Created")
+	res := fmt.Sprintf("%-50s %-50s %-15s %-20s %-15s", "Name", "Description", "Version", "Created", "Platform")
+	return strings.TrimSpace(res)
 }
 
 func (f *FileInfo) String() string {
-	return fmt.Sprintf("%-50s %-50s %-25s %-15s", f.Namespace+"/"+f.Name, f.Description, f.Version, f.Created)
+	return fmt.Sprintf("%-50s %-50s %-15s %-20s", f.Namespace+"/"+f.Name, f.Description, f.Version, f.Created)
 }
 
 func MakeFileInfo(path, ns, name string) *FileInfo {


### PR DESCRIPTION
We modify three capstan commands:

- capstan package init   -> we introduce --platform argument
- capstan package list   -> we add a column to the printed result
- capstan package search -> we add a column to the printed result

The 'platform' attribute is a string e.g. "Ubuntu-14.04" that tells us what platform was the package built on.

In order to be able to unit test the modified output of `capstan package list` we quickly refactor the ListPackages function so that it now returns string (rather than print directly to console).

Depends on https://github.com/mikelangelo-project/capstan/pull/55