### PR TITLE
Let ListImages() return a string instead printing to stdout

### DIFF
--- a/capstan.go
+++ b/capstan.go
@@ -269,7 +269,7 @@ func main() {
 			Usage:     "list images",
 			Action: func(c *cli.Context) error {
 				repo := util.NewRepo(c.GlobalString("u"))
-				repo.ListImages()
+				fmt.Print(repo.ListImages())
 
 				return nil
 			},

--- a/testing/prepare_files.go
+++ b/testing/prepare_files.go
@@ -51,3 +51,8 @@ func PrepareFiles(directory string, files map[string]string) error {
 
 	return nil
 }
+
+func ClearDirectory(directory string) {
+	os.RemoveAll(directory)
+	os.Mkdir(directory, 0777)
+}

--- a/util/s3_repository.go
+++ b/util/s3_repository.go
@@ -52,22 +52,25 @@ func FileInfoHeader() string {
 }
 
 func (f *FileInfo) String() string {
-	return fmt.Sprintf("%-50s %-50s %-15s %-20s", f.Namespace+"/"+f.Name, f.Description, f.Version, f.Created)
+	// Trim "/" prefix if there is one (happens when namespace is empty)
+	name := strings.TrimLeft(f.Namespace+"/"+f.Name, "/")
+	res := fmt.Sprintf("%-50s %-50s %-15s %-20s", name, f.Description, f.Version, f.Created)
+	return strings.TrimSpace(res)
 }
 
-func MakeFileInfo(path, ns, name string) *FileInfo {
+func ParseIndexYaml(path, ns, name string) (*FileInfo, error) {
 	data, err := ioutil.ReadFile(filepath.Join(path, ns, name, "index.yaml"))
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	f := FileInfo{}
 	err = yaml.Unmarshal(data, &f)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	f.Namespace = ns
 	f.Name = name
-	return &f
+	return &f, nil
 }
 
 func RemoteFileInfo(repo_url string, path string) *FileInfo {


### PR DESCRIPTION
With this commit we modify `ListImages` so that it now returns a string, which opens an opportunity to provide unit tests for it. We grab the opportunity and actually provide the unit tests. Having tests in place, we're confident enough to refactor the body of ListImages method that was implemented in a strange way and thus hardly understandable.

Depends on https://github.com/mikelangelo-project/capstan/pull/56