### PR TITLE
Add 'platform' column to the output of `capstan images`

### DIFF
--- a/capstan_test.go
+++ b/capstan_test.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -89,9 +90,8 @@ func TestImportCommand(t *testing.T) {
 		t.Errorf("capstan: %v", err)
 	}
 	outLines := strings.Split(string(out), "\n")
-	if g, e := outLines[1], "example"; g != e {
-		t.Errorf("capstan: want %q, got %q", e, g)
-
+	if g, e := outLines[1], "example .*\n"; regexp.MustCompile(e).MatchString(g) {
+		t.Errorf("capstan: want prefix %q, got %q", e, g)
 	}
 }
 
@@ -135,9 +135,8 @@ func TestRmiCommand(t *testing.T) {
 		t.Errorf("capstan: %v", err)
 	}
 	outLines := strings.Split(string(out), "\n")
-	if g, e := outLines[1]+"\n"+outLines[2], "example1\nexample2"; g != e {
+	if g, e := outLines[1]+"\n"+outLines[2], "example1 .*\nexample2 .*\n"; regexp.MustCompile(e).MatchString(g) {
 		t.Errorf("capstan: want %q, got %q", e, g)
-
 	}
 
 	cmd = runCapstan([]string{"rmi", "example1"}, root)
@@ -156,8 +155,7 @@ func TestRmiCommand(t *testing.T) {
 		t.Errorf("capstan: %v", err)
 	}
 	outLines = strings.Split(string(out), "\n")
-	if g, e := outLines[1], "example2"; g != e {
+	if g, e := outLines[1], "example2 .*\n"; regexp.MustCompile(e).MatchString(g) {
 		t.Errorf("capstan: want %q, got %q", e, g)
-
 	}
 }

--- a/util/repository_test.go
+++ b/util/repository_test.go
@@ -130,10 +130,11 @@ func (s *suite) TestImageList(c *C) {
 				format_version: 1
 				version: 9aba80a
 				created: 2017-08-02 08:16
+				platform: Ubuntu-14.04
 			`,
 			`
 				Name         {39}Description {40}Version {9}Created          {5}Platform
-				mike/myimage {39}description {40}9aba80a {9}2017-08-02 08:16
+				mike/myimage {39}description {40}9aba80a {9}2017-08-02 08:16 {5}Ubuntu-14.04
 			`,
 		},
 		{
@@ -145,7 +146,7 @@ func (s *suite) TestImageList(c *C) {
 			`,
 			`
 				Name         {39}Description {40}Version {9}Created {14}Platform
-				mike/myimage {39}description
+				mike/myimage {39}description {40}        {9}        {14}N/A
 			`,
 		},
 		{
@@ -156,7 +157,7 @@ func (s *suite) TestImageList(c *C) {
 			`,
 			`
 				Name         {39}Description {40}Version {9}Created {14}Platform
-				mike/myimage
+				mike/myimage {39}            {40}        {9}        {14}N/A
 			`,
 		},
 		{
@@ -165,7 +166,7 @@ func (s *suite) TestImageList(c *C) {
 			"",
 			`
 				Name         {39}Description {40}Version {9}Created {14}Platform
-				mike/myimage
+				mike/myimage {39}            {40}        {9}        {14}N/A
 			`,
 		},
 		{
@@ -176,10 +177,11 @@ func (s *suite) TestImageList(c *C) {
 				format_version: 1
 				version: 9aba80a
 				created: 2017-08-02 08:16
+				platform: Ubuntu-14.04
 			`,
 			`
 				Name    {44}Description {40}Version {9}Created          {5}Platform
-				myimage {44}description {40}9aba80a {9}2017-08-02 08:16
+				myimage {44}description {40}9aba80a {9}2017-08-02 08:16 {5}Ubuntu-14.04
 			`,
 		},
 		{
@@ -188,7 +190,7 @@ func (s *suite) TestImageList(c *C) {
 			"",
 			`
 				Name    {44}Description {40}Version {9}Created {14}Platform
-				myimage
+				myimage {44}            {40}        {9}        {14}N/A
 			`,
 		},
 	}

--- a/util/s3_repository.go
+++ b/util/s3_repository.go
@@ -29,6 +29,7 @@ type FileInfo struct {
 	Description string
 	Version     string
 	Created     string
+	Platform    string
 }
 
 type Contents struct {
@@ -54,7 +55,11 @@ func FileInfoHeader() string {
 func (f *FileInfo) String() string {
 	// Trim "/" prefix if there is one (happens when namespace is empty)
 	name := strings.TrimLeft(f.Namespace+"/"+f.Name, "/")
-	res := fmt.Sprintf("%-50s %-50s %-15s %-20s", name, f.Description, f.Version, f.Created)
+	platform := f.Platform
+	if platform == "" {
+		platform = "N/A"
+	}
+	res := fmt.Sprintf("%-50s %-50s %-15s %-20s %-15s", name, f.Description, f.Version, f.Created, platform)
 	return strings.TrimSpace(res)
 }
 


### PR DESCRIPTION
It's useful to know what platform was image built on (e.g. "Ubuntu-14.04"), especially in case of mike/osv-loader since only packages built on compatible platform will work there. With this commit we add additional attribute to the index.yaml of each image.