### PR TITLE
Stop using gopkg.in/yaml.v1 in favor of gopkg.in/yaml.v2

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -31,10 +31,6 @@
 			"Rev": "0938d701e50e580f5925c773055eb6d6b32a0cbc"
 		},
 		{
-			"ImportPath": "gopkg.in/yaml.v1",
-			"Rev": "9f9df34309c04878acc86042b16630b0f696e1de"
-		},
-		{
 			"ImportPath": "gopkg.in/yaml.v2",
 			"Rev": "f7716cbe52baa25d2e9b0d0da546fcf909fc16b4"
 		}

--- a/core/template.go
+++ b/core/template.go
@@ -9,7 +9,7 @@ package core
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"path/filepath"

--- a/hypervisor/gce/gce.go
+++ b/hypervisor/gce/gce.go
@@ -10,7 +10,7 @@ package gce
 import (
 	"fmt"
 	"github.com/mikelangelo-project/capstan/util"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"os/exec"

--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"github.com/mikelangelo-project/capstan/nat"
 	"github.com/mikelangelo-project/capstan/util"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"net"
 	"os"

--- a/hypervisor/vbox/vbox.go
+++ b/hypervisor/vbox/vbox.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"github.com/mikelangelo-project/capstan/nat"
 	"github.com/mikelangelo-project/capstan/util"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"net"

--- a/hypervisor/vmw/vmw.go
+++ b/hypervisor/vmw/vmw.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"github.com/mikelangelo-project/capstan/nat"
 	"github.com/mikelangelo-project/capstan/util"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"net"

--- a/runtime/node_test.go
+++ b/runtime/node_test.go
@@ -10,7 +10,7 @@ package runtime
 import (
 	. "github.com/mikelangelo-project/capstan/testing"
 	. "gopkg.in/check.v1"
-	yaml "gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 )
 
 type nodeSuite struct {

--- a/runtime/python_test.go
+++ b/runtime/python_test.go
@@ -10,7 +10,7 @@ package runtime
 import (
 	. "github.com/mikelangelo-project/capstan/testing"
 	. "gopkg.in/check.v1"
-	yaml "gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 )
 
 type pythonSuite struct {

--- a/util/s3_repository.go
+++ b/util/s3_repository.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/cheggaaa/pb"
 	"github.com/mikelangelo-project/capstan/core"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 )
 
 type FileInfo struct {


### PR DESCRIPTION
Currently, we're using a mixture of two versions of the yaml library: v1 and v2. With this commit we unify this so that only v2 is used everywhere since v1 does not support custom marshallers (which we recently started to be using).
