### PR TITLE
Modernize Java runtime

### DIFF
--- a/Documentation/ConfigurationFiles.md
+++ b/Documentation/ConfigurationFiles.md
@@ -143,6 +143,12 @@ Lets sum up. To prepare appropriate run.yaml file, we must first select one of t
 If we are about to be running NodeJS application, then we opt-in to use runtime named *node*. We get
 the details on how to prepare run.yaml for *node* by using Capstan command.
 
+### Configuration files per runtime
+Below please find example meta/run.yaml configuration file for each supported runtime:
+
+* [Java](./RuntimeJava.md)
+* [Node.js](./RuntimeNode.md)
+
 
 ## Automatic generation of configuration files
 You can create configuration files manually or generate them using Capstan. The latter option does

--- a/Documentation/RuntimeJava.md
+++ b/Documentation/RuntimeJava.md
@@ -1,0 +1,98 @@
+# Runtime `java`
+This document describes how to write a valid `meta/run.yaml` configuration file
+for running **Java** application. Please note that you needn't require Java
+MPM package manually since Capstan will require following package automatically:
+
+```
+- openjdk8-zulu-compact1
+```
+
+## Running .class
+Following configuration can be used to run a javac-compiled Java application inside OSv:
+
+```yaml
+# meta/run.yaml
+
+runtime: java
+
+config_set:
+  hello:
+    main: MyClass
+    args:
+      - Johnny
+```
+
+Where the content of MyClass.java file is:
+
+```java
+public class MyClass
+{
+  public static void main(String[] args)
+   {
+     System.out.println("Hello:");
+     for(String el : args){
+       System.out.printf("- %s\n", el);
+     }
+   }
+}
+```
+Please note that OSv doesn't really need the .java file, but only the .class file that was
+produced like this:
+
+```bash
+$ javac MyClass.java
+```
+
+Example:
+
+```bash
+$ capstan package compose demo
+$ capstan run demo --boot hello
+Command line will be set based on --boot parameter
+Created instance: demo
+Setting cmdline: runscript /run/hello
+OSv v0.24-448-g829bf76
+eth0: 192.168.122.15
+java.so: Starting JVM app using: io/osv/nonisolated/RunNonIsolatedJvmApp
+java.so: Setting Java system classloader to NonIsolatingOsvSystemClassLoader
+Hello:
+- Johnny
+```
+
+## Running .jar
+Following configuration can be used to run .jar file inside OSv:
+
+```yaml
+# meta/run.yaml
+
+runtime: java
+
+config_set:
+  hello:
+    main: /MyClass.jar
+    args:
+      - Johnny
+```
+The MyClass.jar was prepared out of the very same MyClass.java file as provided above by using the following
+set of commands:
+
+```bash
+$ javac MyClass.java
+$ jar cfe MyClass.jar MyClass MyClass.class
+```
+
+Example:
+
+```bash
+$ capstan package compose demo
+$ capstan run demo --boot hello
+Command line will be set based on --boot parameter
+Created instance: demo
+Setting cmdline: runscript /run/hello
+OSv v0.24-448-g829bf76
+eth0: 192.168.122.15
+java.so: Starting JVM app using: io/osv/nonisolated/RunNonIsolatedJvmApp
+java.so: Setting Java system classloader to NonIsolatingOsvSystemClassLoader
+Hello:
+- Johnny
+```

--- a/util/util.go
+++ b/util/util.go
@@ -160,3 +160,12 @@ func ExtendMap(m map[string]string, additional map[string]string) {
 		}
 	}
 }
+
+func StringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
An issue opened by a user trying to run .jar file on OSv pointed out that some more documentation should be provided for each runtime. While we've done this for Node.js already, we're now providing it for Java runtime as well. While providing documentation it turned out that we're actually lacking a proper way to support switching Java package underneath. So with this commit we support this as well.
