### PR TITLE
Redirect QEMU standard error to Capstan 

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -89,6 +89,11 @@ func UploadPackageContents(r *util.Repo, appImage string, uploadPaths map[string
 		return nil, err
 	}
 
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
 	// Finally, let's start the command: launch the VM
 	if err := cmd.Start(); err != nil {
 		return nil, err
@@ -96,6 +101,8 @@ func UploadPackageContents(r *util.Repo, appImage string, uploadPaths map[string
 
 	// Make sure the process is always properly killed, even in case of unhandled exception
 	defer cmd.Process.Kill()
+
+	go io.Copy(os.Stderr, stderr)
 
 	scanner := bufio.NewScanner(stdout)
 	for scanner.Scan() {


### PR DESCRIPTION
Currently in case of QEMU error (which happens when composing an app 
on Mac OSX) capstan does not output any information and eventually 
quits with misleading error message:

```
Setting cmdline: /tools/cpiod.so --prefix /
Could not run QEMU VM. Try to set 'disable_kvm:true' in ~/.capstan/config.yaml
dial tcp [::1]:10000: getsockopt: connection refused
```
In reality QEMU does not start due to some deprecated or incorrect parameters. 
In order for user to see the errors output by QEMU to standard error capstan 
needs to redirect it to its standard error.

After the changes user can see exact error which is much better:
```
Setting cmdline: /tools/cpiod.so --prefix /
qemu-system-x86_64: -redir tcp:10000::10000: The -redir option is deprecated. Please use '-netdev user,hostfwd=...' instead.
qemu-system-x86_64: -drive file=<qemu_file>.qemu,if=none,id=hd0,aio=native,cache=unsafe: aio=native was specified, but is not supported in this build.
Could not run QEMU VM. Try to set 'disable_kvm:true' in ~/.capstan/config.yaml
dial tcp [::1]:10000: getsockopt: connection refused
```
Please note that the underlying problem is fixed in another followup pull request 
that I am ready to submit once this one is merged.

Signed-off-by: Waldemar Kozaczuk <jwkozaczuk@gmail.com> 