### PR TITLE
Remove the RIA acronym from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,6 @@ Congratulations, your unikernel is up-and-running! Press CTRL + C to stop it.
 Capstan is distributed under the 3-clause BSD license.
 
 ## Acknowledgements
-This project  has been conducted within the RIA [MIKELANGELO
-project](https://www.mikelangelo-project.eu) (no.  645402), started in January
-2015, and co-funded by the European Commission under the H2020-ICT- 07-2014:
-Advanced Cloud Infrastructures and Services programme.
-
-
-
+This code has been developed within the [MIKELANGELO project](https://www.mikelangelo-project.eu)
+(no. 645402), started in January 2015, and co-funded by the European Commission under the
+H2020-ICT-07-2014: Advanced Cloud Infrastructures and Services programme.


### PR DESCRIPTION
The RIA acronym is getting obsolete therefore we're removing it from our repository. Also, we're rewording the acknowledgements a little bit to sound more natural.
