### PR TITLE
Optimize storage performance under VirtualBox

### DIFF
--- a/hypervisor/vbox/vbox.go
+++ b/hypervisor/vbox/vbox.go
@@ -110,7 +110,7 @@ func vmCreate(c *VMConfig) error {
 	if err != nil {
 		return err
 	}
-	err = VBoxManage("storagectl", c.Name, "--name", "SATA", "--add", "sata", "--controller", "IntelAHCI")
+	err = VBoxManage("storagectl", c.Name, "--name", "SATA", "--add", "sata", "--controller", "IntelAHCI", "--hostiocache", "on")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Changed hypervisor/vbox/vbox.go by adding "--hostiocache on" option to storagectl
to improve storage performance under VirtualBox. Please see http://underpop.online.fr/v/virtualbox/ch05s07.html for details.

Signed-off-by: Waldemar Kozaczuk <jwkozaczuk@gmail.com>