### PR TITLE
Attach volume on `capstan run`

### DIFF
--- a/Documentation/Volumes.md
+++ b/Documentation/Volumes.md
@@ -1,0 +1,44 @@
+# Attaching volumes
+Capstan supports attaching any number of pre-prepared volumes to the instance. Currenly, you need to prepare
+a volume manually i.e. with external tools, and then export it into a file on your host. During the `capstan run`
+you then provide path to this file together with some metadata.
+
+NOTE: volumes are only supported for QEMU hipervisor at the moment.
+
+## Creating a new volume
+You can create a new volume using qemu-img tool:
+
+```bash
+$ qemu-img create -f qcow2 ./volume.img 1G
+```
+
+## Attaching volumes
+Tell Capstan where your volume is and it will attach it to the instance on run:
+
+```bash
+$ capstan run demo --volume ./volume.img
+```
+
+The volume will get attached as `/dev/vblk1` into the unikernel. The `--volume` argument can be repeated
+to attach multiple volumes:
+
+```bash
+$ capstan run demo --volume ./volume1.img --volume ./volume2.img --volume ./volume3.img
+```
+
+Volumes will get attached as `/dev/vblk1`, `/dev/vblk2`, `/dev/vblk3` in the same order as provided (left-to-right).
+
+### Volume metadata
+You can provide volume metadata for Capstan to be able to attach it as desired:
+
+```bash
+$ capstan run demo --volume ./volume.img:format=qcow2:aio=threads
+```
+
+| KEY | DEFAULT VALUE | VALUES |
+|-------|---------------------|------------|
+| format | raw | raw, qcow2,vdi,vmdk|
+| aio | native | native/threads|
+| cache | none | none/writeback/writethrough/directsync/unsafe|
+
+*Consult [QEMU documentation](https://qemu.weilnetz.de/doc/qemu-doc.html#Block-device-options) for more details.*

--- a/capstan.go
+++ b/capstan.go
@@ -152,6 +152,8 @@ func main() {
 				cli.StringFlag{Name: "boot", Usage: "specify config_set name to boot unikernel with"},
 				cli.BoolFlag{Name: "persist", Usage: "persist instance parameters (only relevant for qemu instances)"},
 				cli.StringSliceFlag{Name: "env", Value: new(cli.StringSlice), Usage: "specify value of environment variable e.g. PORT=8000 (repeatable)"},
+				cli.StringSliceFlag{Name: "volume", Value: new(cli.StringSlice), Usage: `{path}[:{key=val}], e.g. ./volume.img:format=raw (repeatable)
+				Default options are :format=raw:aio=native:cache=none`},
 			},
 			Action: func(c *cli.Context) error {
 				// Check for orphaned instances (those with osv.monitor and disk.qcow2, but
@@ -184,6 +186,7 @@ func main() {
 					MAC:          c.String("mac"),
 					Cmd:          bootCmd,
 					Persist:      c.Bool("persist"),
+					Volumes:      c.StringSlice("volume"),
 				}
 
 				if !isValidHypervisor(config.Hypervisor) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -232,6 +232,7 @@ func RunInstance(repo *util.Repo, config *runtime.RunConfig) error {
 			Cmd:         config.Cmd,
 			DisableKvm:  repo.DisableKvm,
 			Persist:     config.Persist,
+			Volumes:     config.Volumes,
 		}
 
 		cmd, err = qemu.LaunchVM(config)
@@ -244,6 +245,7 @@ func RunInstance(repo *util.Repo, config *runtime.RunConfig) error {
 		if bridge == "" {
 			bridge = "vboxnet0"
 		}
+		volumesNotSupported(config.Volumes)
 		config := &vbox.VMConfig{
 			Name:       id,
 			Dir:        filepath.Join(util.ConfigDir(), "instances/vbox"),
@@ -262,6 +264,7 @@ func RunInstance(repo *util.Repo, config *runtime.RunConfig) error {
 			return fmt.Errorf("%s: image format of %s is not supported, unable to run it.", config.Hypervisor, path)
 		}
 		dir := filepath.Join(util.ConfigDir(), "instances/gce", id)
+		volumesNotSupported(config.Volumes)
 		c := &gce.VMConfig{
 			Name:        id,
 			Image:       id,
@@ -284,6 +287,7 @@ func RunInstance(repo *util.Repo, config *runtime.RunConfig) error {
 			return fmt.Errorf("%s: image format of %s is not supported, unable to run it.", config.Hypervisor, path)
 		}
 		dir := filepath.Join(util.ConfigDir(), "instances/vmw", id)
+		volumesNotSupported(config.Volumes)
 		config := &vmw.VMConfig{
 			Name:         id,
 			Dir:          dir,
@@ -372,4 +376,11 @@ func deleteInstance(name string) error {
 		err = gce.DeleteVM(name)
 	}
 	return err
+}
+
+// volumesNotSupported prints warning if --volume is passed.
+func volumesNotSupported(volumes []string) {
+	if len(volumes) > 0 {
+		fmt.Println("WARNING: --volume is not yet supported for this hypervisor")
+	}
 }

--- a/hypervisor/qemu/qemu_test.go
+++ b/hypervisor/qemu/qemu_test.go
@@ -9,24 +9,123 @@ package qemu
 
 import (
 	"testing"
+
+	. "github.com/mikelangelo-project/capstan/testing"
+	. "gopkg.in/check.v1"
 )
 
-var parsingtests = []struct {
-	in  string
-	out *Version
-}{
-	{"QEMU emulator version 1.0 (qemu-kvm-1.0), Copyright (c) 2003-2008 Fabrice Bellard", &Version{Major: 1, Minor: 0, Patch: 0}},
-	{"QEMU emulator version 1.6.2, Copyright (c) 2003-2008 Fabrice Bellard", &Version{Major: 1, Minor: 6, Patch: 2}},
-	{"QEMU PC emulator version 0.12.1 (qemu-kvm-0.12.1.2), Copyright (c) 2003-2008 Fabrice Bellard", &Version{Major: 0, Minor: 12, Patch: 1}},
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type suite struct{}
+
+var _ = Suite(&suite{})
+
+func (*suite) TestVersionParsing(c *C) {
+	m := []struct {
+		in  string
+		out *Version
+	}{
+		{"QEMU emulator version 1.0 (qemu-kvm-1.0), Copyright (c) 2003-2008 Fabrice Bellard", &Version{Major: 1, Minor: 0, Patch: 0}},
+		{"QEMU emulator version 1.6.2, Copyright (c) 2003-2008 Fabrice Bellard", &Version{Major: 1, Minor: 6, Patch: 2}},
+		{"QEMU PC emulator version 0.12.1 (qemu-kvm-0.12.1.2), Copyright (c) 2003-2008 Fabrice Bellard", &Version{Major: 0, Minor: 12, Patch: 1}},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d", i)
+
+		// This is what we're testing here.
+		version, err := ParseVersion(args.in)
+
+		// Expectations.
+		c.Check(err, IsNil)
+		c.Check(version, DeepEquals, args.out)
+	}
 }
 
-func TestVersionParsing(t *testing.T) {
-	for i, tt := range parsingtests {
-		version, err := ParseVersion(tt.in)
-		if err != nil {
-			t.Errorf("%d. ParseVersion(%q) => error %q, want %q", i, tt.in, err, tt.out)
-		} else if version.Major != tt.out.Major || version.Minor != tt.out.Minor || version.Patch != tt.out.Patch {
-			t.Errorf("%d. ParseVersion(%q) => %q, want %q", i, tt.in, version, tt.out)
+func (*suite) TestVmArguments(c *C) {
+	m := []struct {
+		comment  string
+		config   VMConfig
+		expected []string
+	}{
+		{
+			"basic",
+			VMConfig{},
+			[]string{
+				"-nographic",
+				"-m", "0",
+				"-smp", "0",
+				"-device", "virtio-blk-pci,id=blk0,bootindex=0,drive=hd0",
+				"-drive", "file=,if=none,id=hd0,aio=native,cache=unsafe",
+				"-device", "virtio-rng-pci",
+				"-chardev", "stdio,mux=on,id=stdio,signal=off",
+				"-device", "isa-serial,chardev=stdio",
+				"-netdev", "user,id=un0,net=192.168.122.0/24,host=192.168.122.1",
+				"-device", "virtio-net-pci,netdev=un0",
+				"-chardev", "socket,id=charmonitor,path=,server,nowait",
+				"-mon", "chardev=charmonitor,id=monitor,mode=control",
+			},
+		},
+		{
+			"single volume",
+			VMConfig{
+				Volumes: []string{"/path/vol1.img"},
+			},
+			[]string{
+				"-drive", "file=/path/vol1.img,if=none,id=hd1,aio=native,cache=none,format=raw",
+				"-device", "virtio-blk-pci,id=blk1,bootindex=1,drive=hd1",
+			},
+		},
+		{
+			"single volume with metadata",
+			VMConfig{
+				Volumes: []string{"/path/vol1.img:format=qcow2:aio=threads:cache=writethrough"},
+			},
+			[]string{
+				"-drive", "file=/path/vol1.img,if=none,id=hd1,aio=threads,cache=writethrough,format=qcow2",
+				"-device", "virtio-blk-pci,id=blk1,bootindex=1,drive=hd1",
+			},
+		},
+		{
+			"two volumes",
+			VMConfig{
+				Volumes: []string{"/path/vol1.img", "/path/vol2.img"},
+			},
+			[]string{
+				"-drive", "file=/path/vol1.img,if=none,id=hd1,aio=native,cache=none,format=raw",
+				"-device", "virtio-blk-pci,id=blk1,bootindex=1,drive=hd1",
+				"-drive", "file=/path/vol2.img,if=none,id=hd2,aio=native,cache=none,format=raw",
+				"-device", "virtio-blk-pci,id=blk2,bootindex=2,drive=hd2",
+			},
+		},
+		{
+			"two volumes, one with metadata",
+			VMConfig{
+				Volumes: []string{"/path/vol1.img:format=qcow2", "/path/vol2.img"},
+			},
+			[]string{
+				"-drive", "file=/path/vol1.img,if=none,id=hd1,aio=native,cache=none,format=qcow2",
+				"-device", "virtio-blk-pci,id=blk1,bootindex=1,drive=hd1",
+				"-drive", "file=/path/vol2.img,if=none,id=hd2,aio=native,cache=none,format=raw",
+				"-device", "virtio-blk-pci,id=blk2,bootindex=2,drive=hd2",
+			},
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare.
+		qemuVersion := &Version{Major: 2, Minor: 5, Patch: 0}
+		if args.config.Networking == "" {
+			args.config.Networking = "nat"
 		}
+		args.config.DisableKvm = true
+
+		// This is what we're testing here.
+		qemuArgs, err := args.config.vmArguments(qemuVersion)
+
+		// Expectations.
+		c.Assert(err, IsNil)
+		c.Check(qemuArgs, ContainsArray, args.expected)
 	}
 }

--- a/hypervisor/util.go
+++ b/hypervisor/util.go
@@ -1,0 +1,72 @@
+package hypervisor
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+type Volume struct {
+	Path    string
+	Format  string // raw|qcow2|...
+	AioType string // native|threads
+	Cache   string // none|unsafe|writethrough...
+}
+
+// ParseVolumes parses --volume strings that are of following format:
+// --volume {volumePath}[:{options}]
+// Example: --volume /path/to/myvolume.img:format=raw:aio=native
+func ParseVolumes(volumeStrings []string) ([]Volume, error) {
+	res := []Volume{}
+	if volumeStrings == nil {
+		return res, nil
+	}
+	for _, volumeStr := range volumeStrings {
+		if v, err := parseVolume(volumeStr); err == nil {
+			res = append(res, *v)
+		} else {
+			return res, err
+		}
+
+	}
+	return res, nil
+}
+
+func parseVolume(volumeStr string) (*Volume, error) {
+	v := &Volume{
+		Path:    "",
+		Format:  "raw",
+		AioType: "native",
+		Cache:   "none",
+	}
+
+	for idx, part := range strings.Split(volumeStr, ":") {
+		if idx == 0 { // Volume path
+			if path, err := filepath.Abs(part); err == nil {
+				v.Path = path
+				continue
+			} else {
+				return nil, err
+			}
+		}
+
+		// Volume settings
+		if !strings.Contains(part, "=") {
+			return nil, fmt.Errorf("Please use '=' for assignment of volume settings. Example: --volume /vol.img:format=raw")
+		}
+
+		keyVal := strings.SplitN(part, "=", 2)
+		keyVal[0] = strings.ToLower(keyVal[0])
+		if keyVal[0] == "format" {
+			v.Format = keyVal[1]
+		} else if keyVal[0] == "aio" {
+			v.AioType = keyVal[1]
+		} else if keyVal[0] == "cache" {
+			v.Cache = keyVal[1]
+		} else {
+			return nil, fmt.Errorf("Unknown volume setting: '%s'", keyVal[0])
+		}
+
+	}
+	return v, nil
+}

--- a/hypervisor/util_test.go
+++ b/hypervisor/util_test.go
@@ -1,0 +1,159 @@
+package hypervisor
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type suite struct{}
+
+var _ = Suite(&suite{})
+
+func (*suite) TestParseVolume(c *C) {
+	m := []struct {
+		comment      string
+		volumeString string
+		expected     *Volume
+	}{
+		{
+			"simplest",
+			"/path/to/volume.img",
+			&Volume{
+				Path:    "/path/to/volume.img",
+				Format:  "raw",
+				AioType: "native",
+				Cache:   "none",
+			},
+		},
+		{
+			"format qcow2",
+			"/path/to/volume.img:format=qcow2",
+			&Volume{
+				Path:    "/path/to/volume.img",
+				Format:  "qcow2",
+				AioType: "native",
+				Cache:   "none",
+			},
+		},
+		{
+			"aio threads",
+			"/path/to/volume.img:aio=threads",
+			&Volume{
+				Path:    "/path/to/volume.img",
+				Format:  "raw",
+				AioType: "threads",
+				Cache:   "none",
+			},
+		},
+		{
+			"cache writethrough",
+			"/path/to/volume.img:cache=writethrough",
+			&Volume{
+				Path:    "/path/to/volume.img",
+				Format:  "raw",
+				AioType: "native",
+				Cache:   "writethrough",
+			},
+		},
+		{
+			"three at a time",
+			"/path/to/volume.img:aio=threads:cache=writethrough:format=qcow2",
+			&Volume{
+				Path:    "/path/to/volume.img",
+				Format:  "qcow2",
+				AioType: "threads",
+				Cache:   "writethrough",
+			},
+		},
+		{
+			"uppercase key",
+			"/path/to/volume.img:FORMAT=qcow2",
+			&Volume{
+				Path:    "/path/to/volume.img",
+				Format:  "qcow2",
+				AioType: "native",
+				Cache:   "none",
+			},
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// This is what we're testing here.
+		volume, err := parseVolume(args.volumeString)
+
+		// Expectations.
+		c.Assert(err, IsNil)
+		c.Check(volume, DeepEquals, args.expected)
+	}
+}
+
+func (*suite) TestParseVolumes(c *C) {
+	m := []struct {
+		comment       string
+		volumeStrings []string
+		expected      []string
+	}{
+		{
+			"single volume",
+			[]string{"/volume1.img"},
+			[]string{"/volume1.img"},
+		},
+		{
+			"three volumes, order is preserved",
+			[]string{"/volume1.img", "/volume2.img", "/volume3.img"},
+			[]string{"/volume1.img", "/volume2.img", "/volume3.img"},
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// This is what we're testing here.
+		volumes, err := ParseVolumes(args.volumeStrings)
+
+		// Expectations.
+		c.Assert(err, IsNil)
+		paths := []string{}
+		for _, volume := range volumes {
+			paths = append(paths, volume.Path)
+		}
+		c.Check(paths, DeepEquals, args.expected)
+	}
+}
+
+func (*suite) TestParseVolumeInvalid(c *C) {
+	m := []struct {
+		comment      string
+		volumeString string
+		err          string
+	}{
+		{
+			"only colon",
+			"/path/to/volume.img:",
+			"Please use '=' for assignment of volume settings. Example: --volume /vol.img:format=raw",
+		},
+		{
+			"only key",
+			"/path/to/volume.img:format",
+			"Please use '=' for assignment of volume settings. Example: --volume /vol.img:format=raw",
+		},
+		{
+			"illegal attribute",
+			"/path/to/volume.img:format=qcow2:illegal=value",
+			"Unknown volume setting: 'illegal'",
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// This is what we're testing here.
+		_, err := parseVolume(args.volumeString)
+
+		// Expectations.
+		c.Check(err, ErrorMatches, args.err)
+	}
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -32,19 +32,20 @@ var SupportedRuntimes []RuntimeType = []RuntimeType{
 }
 
 type RunConfig struct {
-	InstanceName string
-	ImageName    string
-	Hypervisor   string
+	InstanceName string // general
 	Verbose      bool
-	Memory       string
-	Cpus         int
-	Networking   string
-	Bridge       string
-	NatRules     []nat.Rule
 	GCEUploadDir string
-	MAC          string
 	Cmd          string
 	Persist      bool
+	Hypervisor   string
+	ImageName    string // storage
+	Volumes      []string
+	Memory       string // resources
+	Cpus         int
+	Networking   string // networking
+	Bridge       string
+	NatRules     []nat.Rule
+	MAC          string
 }
 
 // Runtime interface must be extended for every new runtime.

--- a/testing/checkers_test.go
+++ b/testing/checkers_test.go
@@ -1,0 +1,104 @@
+package testing
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type suite struct{}
+
+var _ = Suite(&suite{})
+
+func (*suite) TestContainsArrayStringCheck(c *C) {
+	m := []struct {
+		comment  string
+		obtained []string
+		expected []string
+		err      string
+	}{
+		{
+			"simplest",
+			[]string{"a", "b", "c"},
+			[]string{"b", "c"},
+			"",
+		},
+		{
+			"full",
+			[]string{"a", "b", "c"},
+			[]string{"a", "b", "c"},
+			"",
+		},
+		{
+			"mismatch #1",
+			[]string{"a", "b", "c"},
+			[]string{"x"},
+			"Obtained array does not contain expected subarray",
+		},
+		{
+			"mismatch #2",
+			[]string{"a", "b", "c"},
+			[]string{"a", "c"},
+			"Obtained array does not contain expected subarray",
+		},
+		{
+			"too short obtained",
+			[]string{"a"},
+			[]string{"x", "y", "z"},
+			"Obtained array is shorter than wanted",
+		},
+		{
+			"empty expected",
+			[]string{"a", "b", "c"},
+			[]string{},
+			"Expected array must not be empty",
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare.
+		obtained := []interface{}{args.obtained, args.expected}
+		names := []string{}
+
+		// This is what we're testing here.
+		isOk, errStr := ContainsArray.Check(obtained, names)
+
+		// Expectations.
+		c.Assert(errStr, Equals, args.err)
+		c.Assert(isOk, Equals, args.err == "")
+	}
+}
+
+func (*suite) TestContainsArrayIntCheck(c *C) {
+	m := []struct {
+		comment  string
+		obtained []int
+		expected []int
+		err      string
+	}{
+		{
+			"simplest",
+			[]int{1, 2, 3},
+			[]int{2, 3},
+			"",
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare.
+		obtained := []interface{}{args.obtained, args.expected}
+		names := []string{}
+
+		// This is what we're testing here.
+		isOk, errStr := ContainsArray.Check(obtained, names)
+
+		// Expectations.
+		c.Assert(errStr, Equals, args.err)
+		c.Assert(isOk, Equals, args.err == "")
+	}
+}


### PR DESCRIPTION
Until now we were not able to attach volume when using Capstan. With this commit we bring basic support for it by introducing following parameter to the command:

```
$ capstan run demo --volume ./test1.img --volume ./volume2.img --volume ./volume3.img
```

At the moment we only support volumes for QEMU hypervisor and print a warning if --volume option is used with any other hypervisor.