### PR TITLE
Enhance package compose to upload files to a remote OSv instance

### DIFF
--- a/capstan.go
+++ b/capstan.go
@@ -464,6 +464,38 @@ func main() {
 					},
 				},
 				{
+					Name:      "compose-remote",
+					Usage:     "composes the package and all its dependencies and uploads resulting files into remote OSv instance",
+					ArgsUsage: "remote-instance",
+					Flags: []cli.Flag{
+						cli.BoolFlag{Name: "verbose, v", Usage: "verbose mode"},
+						cli.BoolFlag{Name: "pull-missing, p", Usage: "attempt to pull packages missing from a local repository"},
+					},
+					Action: func(c *cli.Context) error {
+						if len(c.Args()) != 1 {
+							return cli.NewExitError("Usage: capstan package compose-remote [remote-instance]", EX_USAGE)
+						}
+
+						// Use the provided repository.
+						repo := util.NewRepo(c.GlobalString("u"))
+
+						// Get the remote host instance or IP address where files of the composed package will be uploaded to
+						remoteHostInstance := c.Args().First()
+
+						verbose := c.Bool("verbose")
+						pullMissing := c.Bool("pull-missing")
+
+						// Always use the current directory for the package to compose.
+						packageDir, _ := os.Getwd()
+
+						if err := cmd.ComposePackageAndUploadToRemoteInstance(repo, verbose, pullMissing, packageDir, remoteHostInstance); err != nil {
+							return cli.NewExitError(err.Error(), EX_DATAERR)
+						}
+
+						return nil
+					},
+				},
+				{
 					Name:  "collect",
 					Usage: "collects contents of this package and all required packages",
 					Flags: []cli.Flag{

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -227,6 +227,27 @@ func ComposePackage(repo *util.Repo, imageSize int64, updatePackage, verbose, pu
 	return nil
 }
 
+func ComposePackageAndUploadToRemoteInstance(repo *util.Repo, verbose, pullMissing bool, packageDir, remoteHostInstance string) error {
+
+	// Package content should be collected in a subdirectory called mpm-pkg.
+	targetPath := filepath.Join(packageDir, "mpm-pkg")
+	// Remove collected directory afterwards.
+	defer os.RemoveAll(targetPath)
+
+	// First, collect the contents of the package.
+	if err := CollectPackage(repo, packageDir, pullMissing,"", verbose); err != nil {
+		return err
+	}
+
+	// If all is well, we have to start preparing the files for upload.
+	paths, err := collectDirectoryContents(targetPath)
+	if err != nil {
+		return err
+	}
+
+	return UploadPackageContentsToRemoteGuest(paths, remoteHostInstance, verbose)
+}
+
 // CollectPackage will try to resolve all of the dependencies of the given package
 // and collect the content in the $CWD/mpm-pkg directory.
 func CollectPackage(repo *util.Repo, packageDir string, pullMissing bool, customBoot string, verbose bool) error {

--- a/hypervisor/vbox/vbox.go
+++ b/hypervisor/vbox/vbox.go
@@ -110,7 +110,7 @@ func vmCreate(c *VMConfig) error {
 	if err != nil {
 		return err
 	}
-	err = VBoxManage("storagectl", c.Name, "--name", "SATA", "--add", "sata", "--controller", "IntelAHCI")
+	err = VBoxManage("storagectl", c.Name, "--name", "SATA", "--add", "sata", "--controller", "IntelAHCI", "--hostiocache", "on")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is more of a sketch of a proposal to demonstrate how this can be solved. I do not expect this to merged as is.

The motivation comes from the fact the creating AWS AMIs from OSv raw image is pretty time consuming task and is proportional to the size of the image. The idea is to have 'mike/osv-loader' EC2 instance running with cmdline '--norandom --nomount --noinit /tools/mkfs.so; /tools/cpiod.so --prefix /zfs/zfs; /zfs.so set compression=off osv' and use capstan with option  --remote-guest-name <remote_IP_or_host_name> to upload files that make up an image and set actual cmdline. To make it possible cpiod needs to slightly modified to allow setting cmdline.

I have tested this approach and it works and is faster than import raw image and EC2 snapshot/AMI.