### PR TITLE
Create volumes with Capstan

### DIFF
--- a/Documentation/Volumes.md
+++ b/Documentation/Volumes.md
@@ -6,24 +6,27 @@ you then provide path to this file together with some metadata.
 NOTE: volumes are only supported for QEMU hipervisor at the moment.
 
 ## Creating a new volume
-You can create a new volume using qemu-img tool:
+You can create a new volume with Capstan:
 
 ```bash
-$ qemu-img create -f qcow2 ./volume.img 1G
+$ capstan volume create volume1
 ```
+
+The command above will create a volume of size 1GB in RAW format by default. Consult `capstan volume create --help`
+to learn how other size or other formats can be used. The volume will be created as `./volumes/volume1`.
 
 ## Attaching volumes
 Tell Capstan where your volume is and it will attach it to the instance on run:
 
 ```bash
-$ capstan run demo --volume ./volume.img
+$ capstan run demo --volume ./volumes/volume1
 ```
 
 The volume will get attached as `/dev/vblk1` into the unikernel. The `--volume` argument can be repeated
 to attach multiple volumes:
 
 ```bash
-$ capstan run demo --volume ./volume1.img --volume ./volume2.img --volume ./volume3.img
+$ capstan run demo --volume ./volume1 --volume ./volume2 --volume ./volume3
 ```
 
 Volumes will get attached as `/dev/vblk1`, `/dev/vblk2`, `/dev/vblk3` in the same order as provided (left-to-right).
@@ -32,12 +35,12 @@ Volumes will get attached as `/dev/vblk1`, `/dev/vblk2`, `/dev/vblk3` in the sam
 You can provide volume metadata for Capstan to be able to attach it as desired:
 
 ```bash
-$ capstan run demo --volume ./volume.img:format=qcow2:aio=threads
+$ capstan run demo --volume ./volume1:format=qcow2:aio=threads
 ```
 
 | KEY | DEFAULT VALUE | VALUES |
 |-------|---------------------|------------|
-| format | raw | raw, qcow2,vdi,vmdk|
+| format | raw | raw,qcow2,vdi,vmdk|
 | aio | native | native/threads|
 | cache | none | none/writeback/writethrough/directsync/unsafe|
 

--- a/capstan.go
+++ b/capstan.go
@@ -690,6 +690,66 @@ func main() {
 				},
 			},
 		},
+		{
+			Name:  "volume",
+			Usage: "volume manipulation tools",
+			Subcommands: []cli.Command{
+				{
+					Name:      "create",
+					Usage:     "create empty volume and store it into ./volumes directory",
+					ArgsUsage: "[volume-name]",
+					Flags: []cli.Flag{
+						cli.StringFlag{Name: "size, s", Value: "1G", Usage: "total size of the target image (use M or G suffix)"},
+						cli.StringFlag{Name: "format, f", Usage: "volume format, e.g. [raw|qcow2|vdi|vmdk|...]"},
+					},
+					Action: func(c *cli.Context) error {
+						if len(c.Args()) != 1 {
+							return cli.NewExitError("usage: capstan volume create [volume-name]", EX_USAGE)
+						}
+
+						size, err := util.ParseMemSize(c.String("size"))
+						if err != nil {
+							return cli.NewExitError(fmt.Sprintf("Incorrect image size format: %s", err), EX_DATAERR)
+						}
+
+						volume := cmd.Volume{
+							Volume: hypervisor.Volume{
+								Format: c.String("format"),
+							},
+							SizeMB: size,
+							Name:   c.Args().First(),
+						}
+						packagePath, _ := os.Getwd()
+						if err := cmd.CreateVolume(packagePath, volume); err != nil {
+							return cli.NewExitError(err.Error(), EX_DATAERR)
+						}
+
+						return nil
+					},
+				},
+				{
+					Name:      "delete",
+					Usage:     "delete volume by name",
+					ArgsUsage: "[volume-name]",
+					Flags: []cli.Flag{
+						cli.BoolFlag{Name: "verbose, v", Usage: "verbose mode"},
+					},
+					Action: func(c *cli.Context) error {
+						if len(c.Args()) != 1 {
+							return cli.NewExitError("usage: capstan volume delete [volume-name]", EX_USAGE)
+						}
+						name := c.Args().First()
+
+						packagePath, _ := os.Getwd()
+						if err := cmd.DeleteVolume(packagePath, name, c.Bool("verbose")); err != nil {
+							return cli.NewExitError(err.Error(), EX_DATAERR)
+						}
+
+						return nil
+					},
+				},
+			},
+		},
 	}
 	app.Run(os.Args)
 }

--- a/cmd/volume.go
+++ b/cmd/volume.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2017 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mikelangelo-project/capstan/hypervisor"
+	"github.com/mikelangelo-project/capstan/hypervisor/qemu"
+)
+
+// Volume is an extended version of hypervisor.Volume with volume creation data.
+type Volume struct {
+	hypervisor.Volume
+	SizeMB int64
+	Name   string
+}
+
+const (
+	VOLUMES_DIR           string = "volumes"
+	VOLUME_FORMAT_DEFAULT string = "raw"
+)
+
+// CreateVolume creates volume with given specifications.
+func CreateVolume(packagePath string, volume Volume) error {
+	if _, err := os.Stat(filepath.Join(packagePath, "meta", "package.yaml")); os.IsNotExist(err) {
+		return fmt.Errorf("Must be in package root directory")
+	}
+	volumesDir := filepath.Join(packagePath, VOLUMES_DIR)
+	if _, err := os.Stat(volumesDir); os.IsNotExist(err) {
+		if err := os.Mkdir(volumesDir, 0744); err != nil {
+			return fmt.Errorf("Could not create volumes dir '%s': %s", volumesDir, err)
+		}
+	}
+
+	// Set defaults
+	if volume.Format == "" {
+		volume.Format = VOLUME_FORMAT_DEFAULT
+	}
+
+	// Create actual volume.
+	volume.Path = filepath.Join(volumesDir, fmt.Sprintf(volume.Name))
+	if err := qemu.CreateVolume(volume.Path, volume.Format, volume.SizeMB); err != nil {
+		return fmt.Errorf("Could not create volume: %s", err)
+	}
+
+	// Write metadata.
+	if err := volume.PersistMetadata(); err != nil {
+		return fmt.Errorf("Could not persist volume metadata: %s", err)
+	}
+
+	return nil
+}
+
+// DeleteVolume deletes volume and its metadata with given name.
+func DeleteVolume(packagePath, name string, verbose bool) error {
+	path := filepath.Join(packagePath, VOLUMES_DIR, name)
+	meta := fmt.Sprintf("%s.yaml", path)
+
+	// Remove the volume itself.
+	if _, err := os.Stat(path); err == nil {
+		if err := os.Remove(path); err == nil {
+			if verbose {
+				fmt.Println("Removed volume", path)
+			}
+		} else {
+			return err
+		}
+	} else {
+		return fmt.Errorf("Could not find volume with name '%s'", name)
+	}
+
+	// Remove the metadata if it exists.
+	if _, err := os.Stat(meta); err == nil {
+		if err := os.Remove(meta); err == nil {
+			if verbose {
+				fmt.Println("Removed volume metadata", meta)
+			}
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/volume_test.go
+++ b/cmd/volume_test.go
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2017 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mikelangelo-project/capstan/hypervisor"
+	"github.com/mikelangelo-project/capstan/util"
+
+	. "github.com/mikelangelo-project/capstan/testing"
+	. "gopkg.in/check.v1"
+)
+
+type volumesSuite struct {
+	capstanBinary string
+	packageDir    string
+	packageFiles  map[string]string
+	repo          *util.Repo
+}
+
+func (s *volumesSuite) SetUpTest(c *C) {
+	s.packageDir = c.MkDir()
+	os.Chmod(s.packageDir, 0777)
+}
+
+var _ = Suite(&volumesSuite{})
+
+func (s *volumesSuite) TestCreateVolume(c *C) {
+	m := []struct {
+		comment      string
+		volume       Volume
+		expectedMeta string
+		expectedInfo string
+	}{
+		{
+			"create default format",
+			Volume{
+				SizeMB: 128,
+				Name:   "vol1",
+			},
+			`
+				format: raw
+			`,
+			`
+				file format: raw
+				virtual size: 128M \(134217728 bytes\)
+			`,
+		},
+		{
+			"create qcow2",
+			Volume{
+				Volume: hypervisor.Volume{
+					Format: "qcow2",
+				},
+				SizeMB: 128,
+				Name:   "vol1",
+			},
+			`
+				format: qcow2
+			`,
+			`
+				file format: qcow2
+				virtual size: 128M \(134217728 bytes\)
+			`,
+		},
+		{
+			"create raw",
+			Volume{
+				Volume: hypervisor.Volume{
+					Format: "raw",
+				},
+				SizeMB: 128,
+				Name:   "vol1",
+			},
+			`
+				format: raw
+			`,
+			`
+				file format: raw
+				virtual size: 128M \(134217728 bytes\)
+			`,
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare.
+		volumesDir := filepath.Join(s.packageDir, "volumes")
+		metaFile := filepath.Join(volumesDir, fmt.Sprintf("%s.yaml", args.volume.Name))
+		volumeFile := filepath.Join(volumesDir, args.volume.Name)
+		ClearDirectory(volumesDir)
+		PrepareFiles(s.packageDir, map[string]string{"/meta/package.yaml": PackageYamlText})
+
+		// This is what we're testing here.
+		err := CreateVolume(s.packageDir, args.volume)
+
+		// Expectations.
+		c.Assert(err, IsNil)
+		c.Check(metaFile, FileMatches, FixIndent(args.expectedMeta))
+		c.Check([]string{"qemu-img", "info", volumeFile}, CmdOutputMatches, FixIndent(args.expectedInfo))
+	}
+}
+
+func (s *volumesSuite) TestCreateVolumeInvalidNoPackage(c *C) {
+	// This is what we're testing here.
+	err := CreateVolume(s.packageDir, Volume{})
+
+	// Expectations.
+	c.Check(err, ErrorMatches, "Must be in package root directory")
+}
+
+func (s *volumesSuite) TestCreateVolumeInvalidAlreadyExists(c *C) {
+	// Prepare.
+	PrepareFiles(s.packageDir, map[string]string{
+		"/meta/package.yaml": PackageYamlText,
+		"/volumes/vol1":      DefaultText,
+		"/volumes/vol1.yaml": DefaultText,
+	})
+
+	// This is what we're testing here.
+	err := CreateVolume(s.packageDir, Volume{Name: "vol1", Volume: hypervisor.Volume{Format: "vdi"}})
+
+	// Expectations.
+	c.Check(err, ErrorMatches, "Could not create volume: Volume already exists")
+}
+
+func (s *volumesSuite) TestDeleteVolume(c *C) {
+	m := []struct {
+		comment         string
+		state           map[string]string
+		name            string
+		expectedVolumes map[string]interface{}
+	}{
+		{
+			"simple",
+			map[string]string{
+				"/volumes/vol1":      DefaultText,
+				"/volumes/vol1.yaml": DefaultText,
+			},
+			"vol1",
+			map[string]interface{}{},
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare.
+		volumesDir := filepath.Join(s.packageDir, "volumes")
+		args.state["/meta/package.yaml"] = PackageYamlText
+		PrepareFiles(s.packageDir, args.state)
+
+		// This is what we're testing here.
+		err := DeleteVolume(s.packageDir, args.name, false)
+
+		// Expectations.
+		c.Assert(err, IsNil)
+		c.Check(volumesDir, DirEquals, args.expectedVolumes)
+	}
+}
+
+func (s *volumesSuite) TestDeleteVolumeInvalid(c *C) {
+	m := []struct {
+		comment string
+		state   map[string]string
+		name    string
+		err     string
+	}{
+		{
+			"delete when not even volumes directory exists",
+			map[string]string{},
+			"nonexistent",
+			"Could not find volume with name 'nonexistent'",
+		},
+		{
+			"delete nonexistent",
+			map[string]string{
+				"/volumes/vol1.qcow2":      DefaultText,
+				"/volumes/vol1.qcow2.yaml": DefaultText,
+			},
+			"nonexistent",
+			"Could not find volume with name 'nonexistent'",
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare.
+		args.state["/meta/package.yaml"] = PackageYamlText
+		PrepareFiles(s.packageDir, args.state)
+
+		// This is what we're testing here.
+		err := DeleteVolume(s.packageDir, args.name, false)
+
+		// Expectations.
+		c.Assert(err, ErrorMatches, args.err)
+	}
+}

--- a/core/capstanignore.go
+++ b/core/capstanignore.go
@@ -23,7 +23,7 @@ type Capstanignore interface {
 }
 
 var CAPSTANIGNORE_ALWAYS []string = []string{
-	"/meta/*", "/mpm-pkg", "/.git", "/.capstanignore", "/.gitignore",
+	"/meta/*", "/mpm-pkg", "/.git", "/.capstanignore", "/.gitignore", "/volumes",
 }
 
 // CapstanignoreInit creates a new Capstanignore struct that is

--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -419,3 +419,14 @@ func checkKVM() bool {
 
 	return true
 }
+
+func CreateVolume(path, format string, sizeMB int64) error {
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("Volume already exists")
+	}
+	cmd := exec.Command("qemu-img", "create", "-f", format, path, fmt.Sprintf("%dM", sizeMB))
+	if stdout, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%s\n%s", stdout, err)
+	}
+	return nil
+}

--- a/hypervisor/util.go
+++ b/hypervisor/util.go
@@ -2,15 +2,17 @@ package hypervisor
 
 import (
 	"fmt"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
 	"path/filepath"
 	"strings"
 )
 
 type Volume struct {
-	Path    string
-	Format  string // raw|qcow2|...
-	AioType string // native|threads
-	Cache   string // none|unsafe|writethrough...
+	Path    string `yaml:"-"`
+	Format  string `yaml:"format,omitempty"` // raw|qcow2|...
+	AioType string `yaml:"aio,omitempty"`    // native|threads
+	Cache   string `yaml:"cache,omitempty"`  // none|unsafe|writethrough...
 }
 
 // ParseVolumes parses --volume strings that are of following format:
@@ -69,4 +71,13 @@ func parseVolume(volumeStr string) (*Volume, error) {
 
 	}
 	return v, nil
+}
+
+func (v *Volume) PersistMetadata() error {
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		return err
+	}
+	path := fmt.Sprintf("%s.yaml", v.Path)
+	return ioutil.WriteFile(path, []byte(data), 0644)
 }

--- a/test/core/capstanignore_test.go
+++ b/test/core/capstanignore_test.go
@@ -160,6 +160,10 @@ func (s *testingCapstanignoreSuite) TestIsIgnored(c *C) {
 			"always ignore /.gitignore",
 			"", "/.gitignore", true,
 		},
+		{
+			"always ignore /volumes",
+			"", "/volumes", true,
+		},
 	}
 	for i, args := range m {
 		c.Logf("CASE #%d: %s", i, args.comment)


### PR DESCRIPTION
With this commit we implement a simple wrapper around qemu-img to simplify volume creation for user by using Capstan:

```
$ capstan volume create vol1 --size 1GB --format qcow2
```

The above command needs to be executed inside package (presence of meta/package.yaml is tested) and will create `volumes` directory with two files:

```
<package_root>
  |-volumes
    |-vol1.qcow2      # volume itself
    |-vol1.qcow2.yaml # metadata for Capstan
```

The metadata file is currently not used by Capstan yet, but will be soon since Capstan will automatically detect all the volumes inside ./volumes directory. Also `capstan volume delete` is implemented in this commit and `./volumes` directory is implicitly added to the .capstanignore.