### PR TITLE
Don't require osv.bootstrap when compose-remote

### DIFF
--- a/capstan.go
+++ b/capstan.go
@@ -504,6 +504,7 @@ func main() {
 					Flags: []cli.Flag{
 						cli.BoolFlag{Name: "pull-missing, p", Usage: "attempt to pull packages missing from a local repository"},
 						cli.BoolFlag{Name: "verbose, v", Usage: "verbose mode"},
+						cli.BoolFlag{Name: "remote", Usage: "set when previewing the compose-remote"},
 					},
 					Action: func(c *cli.Context) error {
 						repo := util.NewRepo(c.GlobalString("u"))
@@ -511,7 +512,7 @@ func main() {
 
 						pullMissing := c.Bool("pull-missing")
 
-						if err := cmd.CollectPackage(repo, packageDir, pullMissing, c.Bool("verbose")); err != nil {
+						if err := cmd.CollectPackage(repo, packageDir, pullMissing, c.Bool("remote"), c.Bool("verbose")); err != nil {
 							return cli.NewExitError(err.Error(), EX_DATAERR)
 						}
 


### PR DESCRIPTION
With this commit we implement a logic that decides which packages will be implicitly required when collecting files. In case of `capstan package compose` we require osv.bootstrap while in case of `capstan package compose-remote` we require osv.compose-remote.

Why? When cpiod is running in remote unikernel, we MUST NOT upload the /tools/cpiod.so binary again or it crashes. Therefore we're better of if we omit uploading osv.bootstrap package at all. Instead we rather implicitly require the osv.compose-remote to baby-sit user even further (besides omitting the bootstrap).

Related to:
* https://github.com/mikelangelo-project/capstan-packages/pull/13
* https://groups.google.com/forum/#!topic/osv-dev/ha_ouYegYAc

/cc @wkozaczuk