### PR TITLE
Support running sequential config_sets

### DIFF
--- a/capstan.go
+++ b/capstan.go
@@ -149,7 +149,7 @@ func main() {
 				cli.StringFlag{Name: "gce-upload-dir", Value: "", Usage: "Directory to upload local image to: e.g., gs://osvimg"},
 				cli.StringFlag{Name: "mac", Value: "", Usage: "MAC address. If not specified, the MAC address will be generated automatically."},
 				cli.StringFlag{Name: "execute,e", Usage: "set the command line to execute"},
-				cli.StringFlag{Name: "boot", Usage: "specify config_set name to boot unikernel with"},
+				cli.StringSliceFlag{Name: "boot", Usage: "specify config_set name to boot unikernel with (repeatable, will be run left to right)"},
 				cli.BoolFlag{Name: "persist", Usage: "persist instance parameters (only relevant for qemu instances)"},
 				cli.StringSliceFlag{Name: "env", Value: new(cli.StringSlice), Usage: "specify value of environment variable e.g. PORT=8000 (repeatable)"},
 				cli.StringSliceFlag{Name: "volume", Value: new(cli.StringSlice), Usage: `{path}[:{key=val}], e.g. ./volume.img:format=raw (repeatable)
@@ -164,7 +164,7 @@ func main() {
 
 				bootOpts := cmd.BootOptions{
 					Cmd:     c.String("execute"),
-					Boot:    c.String("boot"),
+					Boot:    c.StringSlice("boot"),
 					EnvList: c.StringSlice("env"),
 				}
 				bootCmd, err := bootOpts.GetCmd()
@@ -424,7 +424,7 @@ func main() {
 						cli.BoolFlag{Name: "verbose, v", Usage: "verbose mode"},
 						cli.StringFlag{Name: "run", Usage: "the command line to be executed in the VM"},
 						cli.BoolFlag{Name: "pull-missing, p", Usage: "attempt to pull packages missing from a local repository"},
-						cli.StringFlag{Name: "boot", Usage: "specify default config_set name to boot unikernel with"},
+						cli.StringSliceFlag{Name: "boot", Usage: "specify default config_set name to boot unikernel with (repeatable, will be run left to right)"},
 						cli.StringSliceFlag{Name: "env", Value: new(cli.StringSlice), Usage: "specify value of environment variable e.g. PORT=8000 (repeatable)"},
 					},
 					Action: func(c *cli.Context) error {
@@ -453,7 +453,7 @@ func main() {
 
 						bootOpts := cmd.BootOptions{
 							Cmd:        c.String("run"),
-							Boot:       c.String("boot"),
+							Boot:       c.StringSlice("boot"),
 							EnvList:    c.StringSlice("env"),
 							PackageDir: packageDir,
 						}
@@ -503,7 +503,6 @@ func main() {
 					Usage: "collects contents of this package and all required packages",
 					Flags: []cli.Flag{
 						cli.BoolFlag{Name: "pull-missing, p", Usage: "attempt to pull packages missing from a local repository"},
-						cli.StringFlag{Name: "boot", Usage: "specify config_set name to boot unikernel with"},
 						cli.BoolFlag{Name: "verbose, v", Usage: "verbose mode"},
 					},
 					Action: func(c *cli.Context) error {
@@ -512,7 +511,7 @@ func main() {
 
 						pullMissing := c.Bool("pull-missing")
 
-						if err := cmd.CollectPackage(repo, packageDir, pullMissing, c.String("boot"), c.Bool("verbose")); err != nil {
+						if err := cmd.CollectPackage(repo, packageDir, pullMissing, c.Bool("verbose")); err != nil {
 							return cli.NewExitError(err.Error(), EX_DATAERR)
 						}
 
@@ -626,7 +625,7 @@ func main() {
 							cli.BoolFlag{Name: "keep-image", Usage: "don't delete local composed image in .capstan/repository/stack"},
 							cli.BoolFlag{Name: "verbose, v", Usage: "verbose mode"},
 							cli.BoolFlag{Name: "pull-missing, p", Usage: "attempt to pull packages missing from a local repository"},
-							cli.StringFlag{Name: "boot", Usage: "specify config_set name to boot unikernel with"},
+							cli.StringSliceFlag{Name: "boot", Usage: "specify config_set name to boot unikernel with (repeatable, will be run left to right)"},
 							cli.StringSliceFlag{Name: "env", Value: new(cli.StringSlice), Usage: "specify value of environment variable e.g. PORT=8000 (repeatable)"},
 						}, openstack.OPENSTACK_CREDENTIALS_FLAGS...),
 					ArgsUsage:   "image-name",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -171,7 +171,7 @@ func RunInstance(repo *util.Repo, config *runtime.RunConfig) error {
 			if err != nil {
 				return err
 			}
-			bootOpts := BootOptions{Boot: config.Cmd}
+			bootOpts := BootOptions{Cmd: config.Cmd}
 			err = ComposePackage(repo, sz, true, false, true, wd, pkg.Name, &bootOpts)
 			if err != nil {
 				return err

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -65,7 +65,7 @@ func OpenStackPush(c *cli.Context) error {
 
 	bootOpts := BootOptions{
 		Cmd:        c.String("run"),
-		Boot:       c.String("boot"),
+		Boot:       c.StringSlice("boot"),
 		EnvList:    c.StringSlice("env"),
 		PackageDir: packageDir,
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -213,12 +213,16 @@ func PrependEnvsPrefix(cmd string, env map[string]string, soft bool) (string, er
 
 // BootCmdForScript returns boot command that is to be used
 // to run config set with name bootName.
-func BootCmdForScript(bootName string) string {
-	if bootName == "" {
+func BootCmdForScript(bootNames []string) string {
+	if len(bootNames) == 0 {
 		return ""
 	}
+	bootCmd := ""
+	for _, bootName := range bootNames {
+		bootCmd += fmt.Sprintf("runscript /run/%s;", strings.TrimSpace(bootName))
+	}
 
-	return fmt.Sprintf("runscript /run/%s", bootName)
+	return bootCmd
 }
 
 // parseBase parses base into pkgName and configSetName.


### PR DESCRIPTION
With this commit we make it possible to use --boot **more than once**, like this:

```
$ capstan package compose demo --boot conf1 --boot conf2 --boot conf3
```

The command above will result in following bootcmd being set:

```
runscript /run/conf1;runscript /run/conf2;runscript /run/conf3
```

With this commit we also support the very same behavior within meta/run.yaml when using config_set_default:

```yaml
runtime: native
config_set:
 ...
config_set_default: conf1,conf2,conf3
```

The config_set_default value "conf1 -> conf2 -> conf3" will result in bootcmd as shown above.