### PR TITLE
Use QEMU aio=threads by default

### DIFF
--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -106,6 +106,7 @@ pairs e.g.
 ```yaml
 repo_url: https://mikelangelo-capstan.s3.amazonaws.com/
 disable_kvm: false
+qemu_aio_type: threads
 ```
 List of supported keys:
 
@@ -113,6 +114,8 @@ List of supported keys:
 packages from.
 * `disable_kvm` by default KVM acceleration is turned on to speed up unikernel creation, but in
 certain circumstances this results in error. Set this to `true` if you have problems using KVM.
+* `qemu_aio_type` by default QEMU aio type is set to "threads" for compatibility reasons. A faster
+option aio is "native", but it's not supported on all platforms.
 
 Please note that if command line argument is used to override the same value (e.g. -u for repository
 URL), then the value from configuration file is ignored.
@@ -129,6 +132,8 @@ List of supported environment variables:
 
 * `CAPSTAN_REPO_URL` overrides the default remote repository URL that is used to fetch precompiled
 packages from.
+* `DISABLE_KVM` [true|false]
+* `QEMU_AIO_TYPE` [threads|native]
 
 Please note that environment variables have the lowest priority - if same variable is set using either
 command-line argument or configuration file, then environment variable is ignored.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -233,6 +233,7 @@ func RunInstance(repo *util.Repo, config *runtime.RunConfig) error {
 			DisableKvm:  repo.DisableKvm,
 			Persist:     config.Persist,
 			Volumes:     config.Volumes,
+			AioType:     repo.QemuAioType,
 		}
 
 		cmd, err = qemu.LaunchVM(config)

--- a/util/repository.go
+++ b/util/repository.go
@@ -32,14 +32,16 @@ const (
 )
 
 type Repo struct {
-	URL        string
-	Path       string
-	DisableKvm bool
+	URL         string
+	Path        string
+	DisableKvm  bool
+	QemuAioType string
 }
 
 type CapstanSettings struct {
-	RepoUrl    string `yaml:"repo_url"`
-	DisableKvm bool   `yaml:"disable_kvm"`
+	RepoUrl     string `yaml:"repo_url"`
+	DisableKvm  bool   `yaml:"disable_kvm"`
+	QemuAioType string `yaml:"qemu_aio_type"`
 }
 
 func NewRepo(url string) *Repo {
@@ -50,8 +52,9 @@ func NewRepo(url string) *Repo {
 
 	// Read configuration file
 	config := CapstanSettings{
-		RepoUrl:    "",
-		DisableKvm: false,
+		RepoUrl:     "",
+		DisableKvm:  false,
+		QemuAioType: "threads",
 	}
 	data, err := ioutil.ReadFile(filepath.Join(root, "config.yaml"))
 	if err == nil {
@@ -77,15 +80,19 @@ func NewRepo(url string) *Repo {
 		return DefaultRepositoryUrl
 	}(url)
 
-	// Attempt to load DisableKvm flag from environment.
+	// Attempt to load flags from environment.
 	if envDisableKvm, err := strconv.ParseBool(os.Getenv("CAPSTAN_DISABLE_KVM")); err == nil {
 		config.DisableKvm = envDisableKvm
 	}
+	if envQemuAioType := os.Getenv("CAPSTAN_QEMU_AIO_TYPE"); envQemuAioType != "" {
+		config.QemuAioType = envQemuAioType
+	}
 
 	return &Repo{
-		URL:        url,
-		Path:       root,
-		DisableKvm: config.DisableKvm,
+		URL:         url,
+		Path:        root,
+		DisableKvm:  config.DisableKvm,
+		QemuAioType: config.QemuAioType,
 	}
 }
 
@@ -101,6 +108,7 @@ func (r *Repo) PrintRepo() {
 	fmt.Printf("CAPSTAN_ROOT: %s\n", r.Path)
 	fmt.Printf("CAPSTAN_REPO_URL: %s\n", r.URL)
 	fmt.Printf("CAPSTAN_DISABLE_KVM: %v\n", r.DisableKvm)
+	fmt.Printf("CAPSTAN_QEMU_AIO_TYPE: %v\n", r.QemuAioType)
 }
 
 func (r *Repo) ImportImage(imageName string, file string, version string, created string, description string, build string) error {


### PR DESCRIPTION
Currently we use `aio=native` by default and then conditionally swap it to `aio=threads` depending on the platform where run. But it seems like that support for "native" is fading away. On Ubuntu 16 it still works, but on Ubuntu 17 it doesn't work anymore. With this commit we therefore use a more general option by default and allow user to explicitly set "native" in $HOME/.capstan/config.yaml when desired.
