### PR TITLE
Update documentation

### DIFF
--- a/Documentation/ConfigurationFiles.md
+++ b/Documentation/ConfigurationFiles.md
@@ -19,7 +19,7 @@ Below please find sample content of meta/package.yaml configuration file:
 ```yaml
 name: my-super-application
 title: DEMO App
-author: lemmy (lemmy@email.com)
+author: myname (myname@email.com)
 require:
     - osv.cli
 ```
@@ -33,27 +33,13 @@ one, `osv.cli`. You can omit the whole attribute if you don't need any
 precompiled packages. A list of all packages in the remote repository can be obtained by executing:
 ```bash
 $ capstan package search
-Name                                               Description                       Version
-app.hadoop-hdfs             Hadoop HDFS                       2.7.2
-app.hello-node              NodeJS-4.4.5                      4.4.5
-app.mysql-5.6.21            MySQL-5.6.21                      5.6.21
-app.node-4.4.5              NodeJS-4.4.5                      4.4.5
-erlang                      Erlang                            18.0
-ompi                        Open MPI                          1.10
-openfoam.core               OpenFOAM Core                     2.4.0
-openfoam.pimplefoam         OpenFOAM pimpleFoam               2.4.0
-openfoam.pisofoam           OpenFOAM pisoFoam                 2.4.0
-openfoam.poroussimplefoam   OpenFOAM porousSimpleFoam         2.4.0
-openfoam.potentialfoam      OpenFOAM potentialFoam            2.4.0
-openfoam.rhoporoussimplefoam OpenFOAM rhoPorousSimpleFoam     2.4.0
-openfoam.rhosimplefoam      OpenFOAM rhoSimpleFoam            2.4.0
-openfoam.simplefoam         OpenFOAM simpleFoam               2.4.0
-osv.bootstrap               OSv Bootstrap                     v0.24-216-g1cf8972
-osv.cli                     OSv Command Line Interface        v0.24-216-g1cf8972
-osv.cloud-init              cloud-init                        v0.24-216-g1cf8972
-osv.httpserver              OSv HTTP REST Server              v0.24-216-g1cf8972
-osv.java                    Java JRE 1.7.0                    v0.24-216-g1cf8972
-osv.nfs                     OSv NFS Client Tools              v0.24-216-g1cf8972
+Name                Description    Version    Created              Platform
+apache.spark-2.1.1  Apache Spark   0.2        2017-08-17 07:36     Ubuntu-14.04
+erlang-7.0          Erlang         0.1        2017-08-17 08:23     Ubuntu-14.04
+mysql-5.6.21        MySQL 5.6.21.  0.1        2017-08-17 08:02     Ubuntu-14.04
+node-4.4.5          NodeJS 4.4.5   0.1        2017-08-17 07:14     Ubuntu-14.04
+node-4.8.2          NodeJS 4.8.2   0.1        2017-08-17 07:43     Ubuntu-14.04
+...
 ```
 Then to download desired package into your local repository execute:
 ```bash
@@ -99,8 +85,9 @@ $ capstan runtime list
 
 RUNTIME    DESCRIPTION                                 DEPENDENCIES
 native     Run arbitrary command inside OSv            []
-node       Run JavaScript NodeJS 4.4.5 application     [app.node-4.4.5]
-java       Run Java 1.7.0 application                  [osv.java]
+node       Run JavaScript NodeJS 4.4.5 application     [node-4.4.5]
+java       Run Java 1.8.0 application                  [openjdk8-zulu-compact1]
+python     Run Python application                      [python-2.7]
 ```
 And then Capstan can tell us what settings are supported for each runtime. For example, for NodeJS
 one can view expected content of the run.yaml file by executing:
@@ -121,7 +108,26 @@ config_set:
       # Note that package root will correspond to filesystem root (/) in OSv image.
       # Example value: /server.js
       main: <filepath>
-
+      
+      # OPTIONAL
+      # A list of Node.js args.
+      # Example value: node_args:
+      #                   - --require module1
+      node_args:
+         - <list>
+      
+      # OPTIONAL
+      # A list of command line args used by the application.
+      # Example value: args:
+      #                   - argument1
+      #                   - argument2
+      args:
+         - <list>
+      
+      # OPTIONAL
+      # Set to true to only run node shell. Note that "main" and "args" will then be ignored.
+      shell: false
+      
       # OPTIONAL
       # Environment variables.
       # A map of environment variables to be set when unikernel is run.
@@ -130,6 +136,10 @@ config_set:
       #                    HOSTNAME: www.myserver.org
       env:
          <key>: <value>
+      
+      # OPTIONAL
+      # Configuration to contextualize.
+      base: "<package-name>:<config_set>" 
 
    # Add as many named configurations as you need
 
@@ -146,8 +156,10 @@ the details on how to prepare run.yaml for *node* by using Capstan command.
 ### Configuration files per runtime
 Below please find example meta/run.yaml configuration file for each supported runtime:
 
+* [Native](./RuntimeNative.md)
 * [Java](./RuntimeJava.md)
 * [Node.js](./RuntimeNode.md)
+* [Python](./RuntimePython.md)
 
 
 ## Automatic generation of configuration files
@@ -161,7 +173,7 @@ To initialize meta/package.yaml file, use:
 $ capstan package init \
    --name "my-super-application" \
    --title "DEMO App" \
-   --author "lemmy (lemmy@email.com)" \
+   --author "myname (myname@email.com)" \
    --require osv.cli
 ```
 This will create a meta subdirectory and ``meta/package.yaml`` file with the

--- a/Documentation/RuntimeNative.md
+++ b/Documentation/RuntimeNative.md
@@ -1,0 +1,47 @@
+# Runtime `native`
+This document describes how to write a valid `meta/run.yaml` configuration file
+for running **native C/C++** application. This is the most basic runtime that depends
+on no MPM package, but rather only invokes the corresponding .so.
+
+## Running own C application
+Bear in mind that you need to compile your application source code on your own, Capstan
+won't do it for you. Furthermore, the system that you're compiling your application on must be compatible
+with the system that base unikernel (mike/osv-loader) was built on, notice the "Platform" column:
+
+```bash
+$ capstan images
+Name             Description       Version   Created             Platform
+mike/osv-loader  OSv Bootloader    d9a8771   2017-11-16 07:46    Ubuntu-14.04
+                                                                     ^                           
+```
+
+This basically means that you need to compile your application on Ubutnu 14.04. If compiling, say, on Ubuntu 16.04,
+then application will most probably crash on OSv. Also, you need to use `-fPIC -shared` flags when compiling. Please
+navigate [here](https://github.com/mikelangelo-project/osv-utils-xlab) to see some example C applications (echo.c,
+sleep.c, cat.c, etc.) as well as corresponding Makefile.
+
+Once application is compiled, you only need to copy the resulting `.so` in Capstan package directory and provide the boot
+command to run it. Following configuration can be used to run your .so application inside OSv, `echo.so` in this example:
+
+```yaml
+# meta/run.yaml
+
+runtime: native
+
+config_set:
+  say_hey:
+    bootcmd: /echo.so Hey hey!
+```
+
+Example:
+
+```bash
+$ capstan package compose demo
+$ capstan run demo --boot say_hey
+Command line will be set based on --boot parameter
+Created instance: demo
+Setting cmdline: runscript /run/echo
+OSv v0.24-434-gf4d1dfb
+eth0: 192.168.122.15
+Hey hey!
+```

--- a/Documentation/generated/CLI.md
+++ b/Documentation/generated/CLI.md
@@ -22,12 +22,13 @@ USAGE:
    capstan package init [command options] [path]
 
 OPTIONS:
-   --name value, -n value     package name
-   --title value, -t value    package title
-   --author value, -a value   package author
-   --version value, -v value  package version
-   --require value            specify package dependency
-   --runtime value            runtime to stub package for. Use 'capstan runtime list' to list all
+   --name value, -n value      package name
+   --title value, -t value     package title
+   --author value, -a value    package author
+   --version value, -v value   package version
+   --require value             specify package dependency
+   --runtime value             runtime to stub package for. Use 'capstan runtime list' to list all
+   -p value, --platform value  platform where package was built on
    
 
 ```
@@ -41,8 +42,9 @@ USAGE:
    capstan package collect [command options] [arguments...]
 
 OPTIONS:
-   --pull-missing, -p           attempt to pull packages missing from a local repository
-   --runconfig value, -r value  specify config_set name (specified in meta/run.yaml)
+   --pull-missing, -p  attempt to pull packages missing from a local repository
+   --boot value        specify config_set name to boot unikernel with
+   --verbose, -v       verbose mode
    
 
 ```
@@ -56,12 +58,13 @@ USAGE:
    capstan package compose [command options] image-name
 
 OPTIONS:
-   --size value, -s value       total size of the target image (use M or G suffix) (default: "10G")
-   --update                     updates the existing target VM by uploading only modified files
-   --verbose, -v                verbose mode
-   --run value                  the command line to be executed in the VM
-   --pull-missing, -p           attempt to pull packages missing from a local repository
-   --runconfig value, -r value  specify config_set name (specified in meta/run.yaml)
+   --size value, -s value  total size of the target image (use M or G suffix) (default: "10G")
+   --update                updates the existing target VM by uploading only modified files
+   --verbose, -v           verbose mode
+   --run value             the command line to be executed in the VM
+   --pull-missing, -p      attempt to pull packages missing from a local repository
+   --boot value            specify default config_set name to boot unikernel with
+   --env value             specify value of environment variable e.g. PORT=8000 (repeatable)
    
 
 ```
@@ -155,18 +158,22 @@ USAGE:
    capstan run [command options] instance-name
 
 OPTIONS:
-   -i value                     image_name
-   -p value                     hypervisor: qemu|vbox|vmw|gce (default: "qemu")
-   -m value                     memory size (default: "1G")
-   -c value                     number of CPUs (default: 2)
-   -n value                     networking: nat|bridge|tap (default: "nat")
-   -v                           verbose mode
-   -b value                     networking device (bridge or tap): e.g., virbr0, vboxnet0, tap0
-   -f value                     port forwarding rules
-   --gce-upload-dir value       Directory to upload local image to: e.g., gs://osvimg
-   --mac value                  MAC address. If not specified, the MAC address will be generated automatically.
-   --execute value, -e value    set the command line to execute
-   --runconfig value, -r value  specify config_set name (specified in meta/run.yaml)
+   -i value                   image_name
+   -p value                   hypervisor: qemu|vbox|vmw|gce (default: "qemu")
+   -m value                   memory size (default: "1G")
+   -c value                   number of CPUs (default: 2)
+   -n value                   networking: nat|bridge|tap|vhost (default: "nat")
+   -v                         verbose mode
+   -b value                   networking device (bridge or tap): e.g., virbr0, vboxnet0, tap0
+   -f value                   port forwarding rules
+   --gce-upload-dir value     Directory to upload local image to: e.g., gs://osvimg
+   --mac value                MAC address. If not specified, the MAC address will be generated automatically.
+   --execute value, -e value  set the command line to execute
+   --boot value               specify config_set name to boot unikernel with
+   --persist                  persist instance parameters (only relevant for qemu instances)
+   --env value                specify value of environment variable e.g. PORT=8000 (repeatable)
+   --volume value             {path}[:{key=val}], e.g. ./volume.img:format=raw (repeatable)
+                                    Default options are :format=raw:aio=native:cache=none
    
 
 ```
@@ -186,21 +193,22 @@ DESCRIPTION:
    Compose package, build .qcow2 image and upload it to OpenStack under nickname <image-name>.
 
 OPTIONS:
-   --size value, -s value       minimal size of the target user partition (use M or G suffix).
-                                NOTE: will be enlarged to match flavor size. (default: "10G")
-   --flavor value, -f value     OpenStack flavor name that created OSv image should fit to
-   --run value                  the command line to be executed in the VM
-   --keep-image                 don't delete local composed image in .capstan/repository/stack
-   --verbose, -v                verbose mode
-   --pull-missing, -p           attempt to pull packages missing from a local repository
-   --runconfig value, -r value  specify config_set name (specified in meta/run.yaml)
-   --OS_AUTH_URL value          OpenStack auth url (e.g. http://10.0.2.15:5000/v2.0)
-   --OS_TENANT_ID value         OpenStack tenant id (e.g. 3dfe7bf545ff4885a3912a92a4a5f8e0)
-   --OS_TENANT_NAME value       OpenStack tenant name (e.g. admin)
-   --OS_PROJECT_NAME value      OpenStack project name (e.g. admin)
-   --OS_USERNAME value          OpenStack username (e.g. admin)
-   --OS_PASSWORD value          OpenStack password (*TODO*: leave blank to be prompted)
-   --OS_REGION_NAME value       OpenStack username (e.g. RegionOne)
+   --size value, -s value    minimal size of the target user partition (use M or G suffix).
+                             NOTE: will be enlarged to match flavor size. (default: "10G")
+   --flavor value, -f value  OpenStack flavor name that created OSv image should fit to
+   --run value               the command line to be executed in the VM
+   --keep-image              don't delete local composed image in .capstan/repository/stack
+   --verbose, -v             verbose mode
+   --pull-missing, -p        attempt to pull packages missing from a local repository
+   --boot value              specify config_set name to boot unikernel with
+   --env value               specify value of environment variable e.g. PORT=8000 (repeatable)
+   --OS_AUTH_URL value       OpenStack auth url (e.g. http://10.0.2.15:5000/v2.0)
+   --OS_TENANT_ID value      OpenStack tenant id (e.g. 3dfe7bf545ff4885a3912a92a4a5f8e0)
+   --OS_TENANT_NAME value    OpenStack tenant name (e.g. admin)
+   --OS_PROJECT_NAME value   OpenStack project name (e.g. admin)
+   --OS_USERNAME value       OpenStack username (e.g. admin)
+   --OS_PASSWORD value       OpenStack password (*TODO*: leave blank to be prompted)
+   --OS_REGION_NAME value    OpenStack username (e.g. RegionOne)
    
 
 ```
@@ -249,8 +257,26 @@ USAGE:
 
 ```
 
+## Contextualizing unikernel remotely
+Commands used to contextualize remote unikernel (i.e. on OpenStack Glance).
+
+### capstan package compose-remote
+```
+NAME:
+   capstan package compose-remote - composes the package and all its dependencies and uploads resulting files into remote OSv instance
+
+USAGE:
+   capstan package compose-remote [command options] remote-instance
+
+OPTIONS:
+   --verbose, -v       verbose mode
+   --pull-missing, -p  attempt to pull packages missing from a local repository
+   
+
+```
+
 ---
-<sup>  Documentation compiled on: 2017/01/06 09:18
+<sup>  Documentation compiled on: 2017/12/18 07:08
   <br>
-  capstan version 
+  capstan version 'v0.2.1-66-g4248dd0'
 </sup>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the first stable release at the moment.*
 
 Capstan is a command-line tool for rapidly running your application on [OSv unikernel](http://osv.io).
 It focuses on improving user experience during building the unikernel and attempts to support
-not only a variety of runtimes (C, C++, Java, NodeJS etc.), but also a variety of ready-to-run
+not only a variety of runtimes (C, C++, Java, Node.js etc.), but also a variety of ready-to-run
 applications (Hadoop HDFS, MySQL, SimpleFOAM etc.).
 
 ## Philosophy
@@ -45,7 +45,6 @@ all still apply. Most notably, you can only run single process inside unikernel 
 
 ## Getting started
 Capstan can be installed using precompiled binary or compiled from source.
-<br>
 [Step-by-step Capstan Installation Guide](Documentation/Installation.md)
 
 Using Capstan is rather simple: open up your project directory and create
@@ -76,8 +75,13 @@ Congratulations, your unikernel is up-and-running! Press CTRL + C to stop it.
 * [Step-by-step Capstan Installation Guide](Documentation/Installation.md)
 * [Running My First Application Inside Unikernel](Documentation/WalkthroughNodeJS.md)
 * [Configuration Files](Documentation/ConfigurationFiles.md)
+    * [Native](Documentation/RuntimeNative.md)
+    * [Java](Documentation/RuntimeJava.md)
+    * [Node.js](Documentation/RuntimeNode.md)
+    * [Python](Documentation/RuntimePython.md)
+* [.capstanignore](Documentation/Capstanignore.md)
+* [Attaching volumes](Documentation/Volumes.md)
 * [CLI Reference](Documentation/generated/CLI.md)
-* [Under the Hood](Documentation/UnderTheHood.md)
 
 ## License
 Capstan is distributed under the 3-clause BSD license.

--- a/scripts/generate_cli_doc.py
+++ b/scripts/generate_cli_doc.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #
 # This script is meant to be run manually when you introduce a change in capstan API.
 # It stores capstan --help texts into markdown file so that user is able to read them without
@@ -66,6 +67,10 @@ GROUPS = [
     Group('Configuring Capstan tool',
           'Commands used to configure Capstan.', [
               Command('capstan config print'),
+          ]),
+    Group('Contextualizing unikernel remotely',
+          'Commands used to contextualize remote unikernel (i.e. on OpenStack Glance).', [
+              Command('capstan package compose-remote'),
           ]),
 ]
 


### PR DESCRIPTION
With this commit we add example for native runtime yaml and update some minor things in other docs. Also, we re-run the script that generates online Capstan documentation.