### PR TITLE
Set aio-thread also when composing/building

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -97,6 +97,7 @@ func UploadRPM(r *util.Repo, hypervisor string, image string, template *core.Tem
 		Networking:  "nat",
 		NatRules:    []nat.Rule{nat.Rule{GuestPort: "10000", HostPort: "10000"}},
 		BackingFile: false,
+		AioType:     r.QemuAioType,
 	}
 	vm, err := qemu.LaunchVM(vmconfig)
 	if err != nil {
@@ -199,6 +200,7 @@ func UploadFiles(r *util.Repo, hypervisor string, image string, t *core.Template
 		NatRules:    []nat.Rule{nat.Rule{GuestPort: "10000", HostPort: "10000"}},
 		BackingFile: false,
 		DisableKvm:  r.DisableKvm,
+		AioType:     r.QemuAioType,
 	}
 	cmd, err := qemu.VMCommand(vmconfig)
 	if err != nil {

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -77,6 +77,7 @@ func UploadPackageContents(r *util.Repo, appImage string, uploadPaths map[string
 		BackingFile: false,
 		Cmd:         osvCmdline,
 		DisableKvm:  r.DisableKvm,
+		AioType:     r.QemuAioType,
 	}
 
 	// TODO Have to come up with a better error handling if necessary. Be more verbose on errors.


### PR DESCRIPTION
With previous commit we handle setting aio option when running unikernel, but we didn't handle the implicit unikernel run that occurs during the composing/building phase. This resulted in error since QEMU was provided with empty string "" as aio-type, which didn't work.