### PR TITLE
Respect CAPSTAN_ROOT environment variable on instance run

### DIFF
--- a/util/repository.go
+++ b/util/repository.go
@@ -45,10 +45,7 @@ type CapstanSettings struct {
 }
 
 func NewRepo(url string) *Repo {
-	root := os.Getenv("CAPSTAN_ROOT")
-	if root == "" {
-		root = filepath.Join(HomePath(), "/.capstan/")
-	}
+	root := ConfigDir()
 
 	// Read configuration file
 	config := CapstanSettings{

--- a/util/util.go
+++ b/util/util.go
@@ -21,7 +21,11 @@ import (
 )
 
 func ConfigDir() string {
-	return filepath.Join(HomePath(), ".capstan")
+	root := os.Getenv("CAPSTAN_ROOT")
+	if root == "" {
+		root = filepath.Join(HomePath(), "/.capstan/")
+	}
+	return root
 }
 
 func HomePath() string {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package util
+
+import (
+	"os"
+
+	. "gopkg.in/check.v1"
+)
+
+type utilSuite struct{}
+
+func (s *utilSuite) SetUpTest(c *C) {}
+
+var _ = Suite(&utilSuite{})
+
+func (*utilSuite) TestConfigDir(c *C) {
+	m := []struct {
+		comment  string
+		env      map[string]string
+		expected string
+	}{
+		{
+			"simplest case",
+			map[string]string{
+				"HOME": "/my/home",
+			},
+			"/my/home/.capstan",
+		},
+		{
+			"with CAPSTAN_ROOT",
+			map[string]string{
+				"HOME":         "/my/home",
+				"CAPSTAN_ROOT": "/capstan/root",
+			},
+			"/capstan/root",
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare.
+		originalEnv := setEnvironmentVars(args.env)
+
+		// This is what we're testing here.
+		dir := ConfigDir()
+
+		// Expectations.
+		c.Check(dir, Equals, args.expected)
+
+		// Restore original environemt variables
+		setEnvironmentVars(originalEnv)
+	}
+}
+
+//
+// Utility
+//
+
+func setEnvironmentVars(env map[string]string) map[string]string {
+	original := map[string]string{}
+	for key, value := range env {
+		original[key] = value
+		os.Setenv(key, value)
+	}
+	return original
+}


### PR DESCRIPTION
Function ConfigDir did not respect CAPSTAN_ROOT environment variable which resulted in instances always being run in the default $HOME/.capstan/instances directory. With this commit we fix this so that when CAPSTAN_ROOT is used, all three subdirectories are created like this:

```
CAPSTAN_ROOT/repository
CAPSTAN_ROOT/packages
CAPSTAN_ROOT/instances <--- this was in ~/.capstan/instances before
```

Fixes https://github.com/mikelangelo-project/capstan/issues/30