### PR TITLE
Add Python runtime to runtime list

### DIFF
--- a/capstan.go
+++ b/capstan.go
@@ -715,7 +715,7 @@ func main() {
 					Usage: "list available runtimes",
 					Flags: []cli.Flag{},
 					Action: func(c *cli.Context) error {
-						cmd.RuntimeList()
+						fmt.Print(cmd.RuntimeList())
 
 						return nil
 					},

--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -74,13 +74,13 @@ func RuntimeInit(runtimeName string, plain bool, force bool) error {
 	return nil
 }
 
-func RuntimeList() error {
-	fmt.Printf("%-20s%-50s%-20s\n", "RUNTIME", "DESCRIPTION", "DEPENDENCIES")
+func RuntimeList() string {
+	res := fmt.Sprintf("%-20s%-50s%-20s\n", "RUNTIME", "DESCRIPTION", "DEPENDENCIES")
 	for _, runtimeType := range runtime.SupportedRuntimes {
 		rt, _ := runtime.PickRuntime(runtimeType)
-		fmt.Printf("%-20s%-50s%-20s\n", string(runtimeType), rt.GetRuntimeDescription(), rt.GetDependencies())
+		res += fmt.Sprintf("%-20s%-50s%-20s\n", string(runtimeType), rt.GetRuntimeDescription(), rt.GetDependencies())
 	}
-	return nil
+	return res
 }
 
 func removeComments(s string) string {

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2018 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package cmd
+
+import (
+	. "github.com/mikelangelo-project/capstan/testing"
+	. "gopkg.in/check.v1"
+)
+
+type runtimeSuite struct{}
+
+var _ = Suite(&runtimeSuite{})
+
+func (s *suite) TestRuntimeList(c *C) {
+	// This is what we're testing here.
+	txt := RuntimeList()
+
+	// Expectations.
+	expected := `
+		RUNTIME {13}DESCRIPTION                             {11}DEPENDENCIES {8}
+		native  {13}Run arbitrary command inside OSv        {11}\[\]
+		node    {13}Run JavaScript NodeJS 4.4.5 application {11}\[node-4.4.5          \]
+		java    {13}Run Java application                    {11}\[openjdk8-zulu-compact1\]
+		python  {13}Run Python 2.7 application              {11}\[python-2.7          \]
+	`
+	c.Check(txt, MatchesMultiline, FixIndent(expected))
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -29,6 +29,7 @@ var SupportedRuntimes []RuntimeType = []RuntimeType{
 	Native,
 	NodeJS,
 	Java,
+	Python,
 }
 
 type RunConfig struct {


### PR DESCRIPTION
Somehow Python was missing from runtime list. With this commit we add it there along with unit test to prevent this from ever happening again. To do this, we had to quickly refactor the print function, nothing big.

Fixes https://github.com/mikelangelo-project/capstan/issues/79