### PR TITLE
Implement `capstan package update` command

### DIFF
--- a/capstan.go
+++ b/capstan.go
@@ -607,6 +607,31 @@ func main() {
 						return nil
 					},
 				},
+				{
+					Name:      "update",
+					Usage:     "updates local packages from remote if remote version is newer",
+					ArgsUsage: "[package-name]",
+					Flags: []cli.Flag{
+						cli.BoolFlag{Name: "created", Usage: "update package also if created date is newer (regardless version)"},
+						cli.BoolFlag{Name: "verbose, v", Usage: "verbose mode"},
+					},
+					Action: func(c *cli.Context) error {
+						// Initialise the repository
+						repo := util.NewRepo(c.GlobalString("u"))
+
+						search := ""
+						if len(c.Args()) > 0 {
+							search = c.Args().First()
+						}
+
+						// Update the package
+						if err := cmd.UpdatePackages(repo, search, c.Bool("created"), c.Bool("verbose")); err != nil {
+							return cli.NewExitError(err.Error(), EX_DATAERR)
+						}
+
+						return nil
+					},
+				},
 			},
 		},
 		{

--- a/core/yaml.go
+++ b/core/yaml.go
@@ -52,3 +52,11 @@ func (t YamlTime) String() string {
 		return "N/A"
 	}
 }
+
+func (t YamlTime) GetTime() *time.Time {
+	if v, ok := t.Time.(time.Time); ok {
+		return &v
+	} else {
+		return nil
+	}
+}

--- a/util/s3_repository.go
+++ b/util/s3_repository.go
@@ -305,3 +305,27 @@ func IsRemotePackage(repo_url, name string) (bool, error) {
 
 	return false, nil
 }
+
+func NeedsUpdate(localPkg, remotePkg *core.Package, compareCreated bool) (bool, error) {
+	// Compare Version attribute.
+	localVersion, err := VersionStringToInt(localPkg.Version)
+	if err != nil {
+		return true, err
+	}
+	remoteVersion, err := VersionStringToInt(remotePkg.Version)
+	if err != nil {
+		return true, err
+	}
+	needsUpdate := localVersion < remoteVersion
+	if needsUpdate || !compareCreated {
+		return needsUpdate, nil
+	}
+
+	// Compare Created attribute.
+	createdLocal := localPkg.Created.GetTime()
+	createdRemote := remotePkg.Created.GetTime()
+	if createdLocal == nil || createdRemote == nil {
+		return true, nil
+	}
+	return createdLocal.Before(*createdRemote), nil
+}

--- a/util/s3_repository_test.go
+++ b/util/s3_repository_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2018 XLAB, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package util
+
+import (
+	"github.com/mikelangelo-project/capstan/core"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+type s3repoSuite struct{}
+
+var _ = Suite(&s3repoSuite{})
+
+func (*s3repoSuite) TestNeedsUpdate(c *C) {
+	m := []struct {
+		comment             string
+		localPkg            core.Package
+		localCreated        string
+		remotePkg           core.Package
+		remoteCreated       string
+		compareCreated      bool
+		expectedNeedsUpdate bool
+	}{
+		{
+			"regular case",
+			core.Package{Version: "4.12.10"}, "",
+			core.Package{Version: "5.0.0"}, "",
+			false,
+			true,
+		},
+		{
+			"already latest",
+			core.Package{Version: "4.12.10"}, "",
+			core.Package{Version: "4.12.10"}, "",
+			false,
+			false,
+		},
+		{
+			"local ahead of remote",
+			core.Package{Version: "4.12.10"}, "",
+			core.Package{Version: "3.0.0"}, "",
+			false,
+			false,
+		},
+		{
+			"needs update #major",
+			core.Package{Version: "4.12.10"}, "",
+			core.Package{Version: "5.12.10"}, "",
+			false,
+			true,
+		},
+		{
+			"needs update #minor",
+			core.Package{Version: "4.12.10"}, "",
+			core.Package{Version: "4.13.10"}, "",
+			false,
+			true,
+		},
+		{
+			"needs update #patch",
+			core.Package{Version: "4.12.10"}, "",
+			core.Package{Version: "4.13.11"}, "",
+			false,
+			true,
+		},
+		{
+			"update because of time created",
+			core.Package{Version: "4.12.10"}, "2018-01-05 07:44",
+			core.Package{Version: "4.12.10"}, "2018-01-05 07:45",
+			true,
+			true,
+		},
+		{
+			"both version and time created are latest",
+			core.Package{Version: "4.12.10"}, "2018-01-05 07:44",
+			core.Package{Version: "4.12.10"}, "2018-01-05 07:44",
+			true,
+			false,
+		},
+		{
+			"time created invalid",
+			core.Package{Version: "4.12.10"}, "invalid",
+			core.Package{Version: "4.12.10"}, "invalid",
+			true,
+			true,
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// Prepare.
+		if t, err := time.Parse(core.FRIENDLY_TIME_F, args.localCreated); err == nil {
+			args.localPkg.Created = core.YamlTime{t}
+		}
+		if t, err := time.Parse(core.FRIENDLY_TIME_F, args.remoteCreated); err == nil {
+			args.remotePkg.Created = core.YamlTime{t}
+		}
+
+		// This is what we're testing here.
+		res, err := NeedsUpdate(&args.localPkg, &args.remotePkg, args.compareCreated)
+
+		// Expectations.
+		c.Check(err, IsNil)
+		c.Check(res, Equals, args.expectedNeedsUpdate)
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -16,7 +16,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -172,4 +175,19 @@ func StringInSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// VersionStringToInt converts 1.2.3 into 1002003 to make it comparable.
+func VersionStringToInt(version string) (int, error) {
+	if ok, _ := regexp.MatchString(`^\d{1,3}(\.\d{1,3}){0,2}$`, version); !ok {
+		return 0, fmt.Errorf("Invalid version string: '%s'", version)
+	}
+	res := 0
+	weight := 1000000
+	for _, part := range strings.Split(version, ".") {
+		n, _ := strconv.Atoi(part)
+		res += weight * n
+		weight /= 1000
+	}
+	return res, nil
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -15,8 +15,6 @@ import (
 
 type utilSuite struct{}
 
-func (s *utilSuite) SetUpTest(c *C) {}
-
 var _ = Suite(&utilSuite{})
 
 func (*utilSuite) TestConfigDir(c *C) {
@@ -55,6 +53,108 @@ func (*utilSuite) TestConfigDir(c *C) {
 
 		// Restore original environemt variables
 		setEnvironmentVars(originalEnv)
+	}
+}
+
+func (*utilSuite) TestVersionStringToInt(c *C) {
+	m := []struct {
+		comment  string
+		version  string
+		expected int
+	}{
+		{
+			"regular case",
+			"4.12.10",
+			4012010,
+		},
+		{
+			"major version",
+			"15.0.0",
+			15000000,
+		},
+		{
+			"minor version",
+			"0.15.0",
+			15000,
+		},
+		{
+			"patch",
+			"0.0.15",
+			15,
+		},
+		{
+			"missing patch",
+			"0.15",
+			15000,
+		},
+		{
+			"missing minor",
+			"15",
+			15000000,
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// This is what we're testing here.
+		res, err := VersionStringToInt(args.version)
+
+		// Expectations.
+		c.Check(err, IsNil)
+		c.Check(res, Equals, args.expected)
+	}
+}
+
+func (*utilSuite) TestVersionStringToIntInvalid(c *C) {
+	m := []struct {
+		comment     string
+		version     string
+		expectedErr string
+	}{
+		{
+			"completely wrong version",
+			"x",
+			"Invalid version string: 'x'",
+		},
+		{
+			"partially wrong version",
+			"1.x.3",
+			"Invalid version string: '1.x.3'",
+		},
+		{
+			"empty version",
+			"",
+			"Invalid version string: ''",
+		},
+		{
+			"continues after patch",
+			"1.2.3.4",
+			"Invalid version string: '1.2.3.4'",
+		},
+		{
+			"major greater than 999",
+			"1000.2.3",
+			"Invalid version string: '1000.2.3'",
+		},
+		{
+			"minor greater than 999",
+			"1.2000.3",
+			"Invalid version string: '1.2000.3'",
+		},
+		{
+			"patch greater than 999",
+			"1.2.3000",
+			"Invalid version string: '1.2.3000'",
+		},
+	}
+	for i, args := range m {
+		c.Logf("CASE #%d: %s", i, args.comment)
+
+		// This is what we're testing here.
+		_, err := VersionStringToInt(args.version)
+
+		// Expectations.
+		c.Check(err, ErrorMatches, args.expectedErr)
 	}
 }
 


### PR DESCRIPTION
With this command user is now able to update all her local packages with those on the S3 repository. Usage is following:

```
$ capstan package update -v
[01/28] apache.spark-2.1.1                                ... already latest
[02/28] erlang-7.0                                        ... already latest
[03/28] mysql-5.6.21                                      ... already latest
[04/28] node-4.4.5                                        ... already latest
[05/28] node-4.8.2                                        ... already latest
[06/28] node-6.10.2                                       ... already latest
[07/28] ompi-1.10                                         ... already latest
[08/28] openfoam.core-2.4.0                               ... already latest
[09/28] openfoam.pimplefoam-2.4.0                         ... already latest
[10/28] openfoam.pisofoam-2.4.0                           ... already latest
[11/28] openfoam.poroussimplefoam-2.4.0                   ... already latest
[12/28] openfoam.potentialfoam-2.4.0                      ... already latest
[13/28] openfoam.rhoporoussimplefoam-2.4.0                ... already latest
[14/28] openfoam.rhosimplefoam-2.4.0                      ... already latest
[15/28] openfoam.simplefoam-2.4.0                         ... already latest
[16/28] openjdk7                                          ... already latest
[17/28] openjdk8-zulu-compact1                            ... already latest
[18/28] openjdk8-zulu-compact3-with-java-beans            ... already latest
[19/28] osv.bootstrap                                     ... already latest
[20/28] osv.cli                                           ... already latest
[21/28] osv.cloud-init                                    ... already latest
[22/28] osv.compose-remote-base                           ... package does not exist in remote repository
[23/28] osv.compose-remote                                ... package does not exist in remote repository
[24/28] osv.httpserver-api                                ... already latest
[25/28] osv.httpserver-html5-gui                          ... already latest
[26/28] osv.nfs                                           ... already latest
[27/28] python-2.7                                        ... already latest
[28/28] sample-0.1                                        ... updating 0.0 -> 0.1
Downloading sample-0.1.yaml...
 179 B / 179 B [===================================================] 100.00% 0s
Downloading sample-0.1.mpm...
 735 B / 735 B [===================================================] 100.00% 0s
package successfully updated
Updated 1 packages (out of 28 that were found locally)
```

Capstan checks if there is higher version on S3 repository for each package in user's local repository and pulls such packages. By default all local packages are updated, but "search" argument can be passed to update only packages with specific name. Also, by default only package version is compared to that of S3, but also Create field can be used by setting --created flag:

```
$ capstan package update spark --created
```

The command above will update any package containing "spark" in its name if a more recent version is found (i.e. with higher version or more recent Created time).

Fixes https://github.com/mikelangelo-project/capstan/issues/47