### PR TITLE
Add support to compose OSv images with ROFS (Read-Only Filesystem)

### DIFF
--- a/Documentation/ApplicationManagement.md
+++ b/Documentation/ApplicationManagement.md
@@ -395,6 +395,8 @@ OSv loader and executed immediately after the kernel is booted
 
 * ``--verbose``: get detailed information about the files that are being uploaded onto the VM
 
+* ``--fs``: specify the OSv filesystem type; the allowed values are ``zfs`` (Zeta File System) or ``rofs`` (Read-Only File System), ``zfs`` is the default filesystem
+
 To compose a VM image, simply execute
 
 ```

--- a/Documentation/OsvFilesystem.md
+++ b/Documentation/OsvFilesystem.md
@@ -1,0 +1,22 @@
+# Filesystems
+
+OSv unikernel supports multiple filesystems - ZFS (Zeta File System), ROFS (Read-Only File System) and RamFS.
+This means that user can build an image, run it and have OSv mount one of these filesystems. 
+
+## ZFS
+ZFS is the original and default filesystem OSv images built by Capstan come with. ZFS is very performant read-write file system
+ideal for running stateful apps on OSv when data needs to be changed and persisted. For more details please
+read [this](https://github.com/cloudius-systems/osv/wiki/ZFS) and [that](https://github.com/cloudius-systems/osv/wiki/Managing-your-storage).
+
+## ROFS
+Read-Only Filesystem has been added recently to OSv and requires 
+[latest version 0.51](https://github.com/cloudius-systems/osv/releases/tag/v0.51.0). As the name suggests ROFS allows only
+reading data from files and therefore well suites running stateless applications on OSv when only code has to be accessed. For more details
+look at [this commit](https://github.com/cloudius-systems/osv/commit/cd449667b7f86721095ddf4f9f3f8b87c1c414c9) and
+[original Python script](https://github.com/cloudius-systems/osv/blob/master/scripts/gen-rofs-img.py).
+
+## Composing packages
+When composing OSv images using ```capstan package compose```, please select desired filesystem using new ```-fs``` option like so:
+```
+capstan package compose --fs rofs <my-package-name>
+```

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Congratulations, your unikernel is up-and-running! Press CTRL + C to stop it.
 * [Attaching volumes](Documentation/Volumes.md)
 * [Capstan S3 Repository](Documentation/Repository.md)
 * [CLI Reference](Documentation/generated/CLI.md)
+* [OSv filesystem](Documentation/OsvFilesystem.md)
 
 ## License
 Capstan is distributed under the 3-clause BSD license.

--- a/capstan.go
+++ b/capstan.go
@@ -426,6 +426,7 @@ func main() {
 						cli.BoolFlag{Name: "pull-missing, p", Usage: "attempt to pull packages missing from a local repository"},
 						cli.StringSliceFlag{Name: "boot", Usage: "specify default config_set name to boot unikernel with (repeatable, will be run left to right)"},
 						cli.StringSliceFlag{Name: "env", Value: new(cli.StringSlice), Usage: "specify value of environment variable e.g. PORT=8000 (repeatable)"},
+						cli.StringFlag{Name: "fs", Usage: "specify type of filesystem: zfs or rofs"},
 					},
 					Action: func(c *cli.Context) error {
 						if len(c.Args()) != 1 {
@@ -458,8 +459,13 @@ func main() {
 							PackageDir: packageDir,
 						}
 
+						filesystem := c.String("fs")
+						if filesystem == "" || (filesystem != "zfs" && filesystem != "rofs") {
+							filesystem = "zfs"
+						}
+
 						if err := cmd.ComposePackage(repo, imageSize, updatePackage, verbose, pullMissing,
-							packageDir, appName, &bootOpts); err != nil {
+							packageDir, appName, &bootOpts, filesystem); err != nil {
 							return cli.NewExitError(err.Error(), EX_DATAERR)
 						}
 

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -19,16 +19,16 @@ import (
 	"github.com/mikelangelo-project/capstan/util"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
-	"net"
 )
 
 func Compose(r *util.Repo, loaderImage string, imageSize int64, uploadPath string, appName string) error {
 	// Initialize an empty image based on the provided loader image. imageSize is used to
 	// determine the size of the user partition.
-	err := r.InitializeImage(loaderImage, appName, imageSize)
+	err := r.InitializeZfsImage(loaderImage, appName, imageSize)
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,7 @@ func UploadPackageContentsToRemoteGuest(uploadPaths map[string]string, remoteHos
 
 	fmt.Printf("Uploading files to %s...\n", remoteHostNameOrIpAddress)
 
-	conn, err := util.ConnectAndWait("tcp", remoteHostNameOrIpAddress + ":10000")
+	conn, err := util.ConnectAndWait("tcp", remoteHostNameOrIpAddress+":10000")
 	if err != nil {
 		if strings.Contains(err.Error(), "getsockopt: connection refused") {
 			fmt.Println("Could not connect to " + remoteHostNameOrIpAddress)

--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -210,7 +210,7 @@ func (*suite) TestComposeNonPackageFails(c *C) {
 	imageSize, _ := util.ParseMemSize("64M")
 	appName := "test-app"
 
-	err := ComposePackage(repo, imageSize, false, false, false, tmp, appName, &BootOptions{})
+	err := ComposePackage(repo, imageSize, false, false, false, tmp, appName, &BootOptions{}, "zfs")
 
 	c.Assert(err, NotNil)
 }
@@ -231,12 +231,12 @@ func (*suite) TestComposeCorruptPackageFails(c *C) {
 	imageSize, _ := util.ParseMemSize("64M")
 	appName := "test-app"
 
-	err = ComposePackage(repo, imageSize, false, false, false, tmp, appName, &BootOptions{})
+	err = ComposePackage(repo, imageSize, false, false, false, tmp, appName, &BootOptions{}, "zfs")
 	c.Assert(err, NotNil)
 }
 
 func (*suite) TestCollectDirectoryContents(c *C) {
-	paths, err := collectDirectoryContents("testdata/hashing")
+	paths, err := CollectDirectoryContents("testdata/hashing")
 	c.Assert(err, IsNil)
 
 	expectedPaths := []string{"file1", "symlink-to-file1", "dir2", "dir2/file-in-dir2", "dir1",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -172,7 +172,7 @@ func RunInstance(repo *util.Repo, config *runtime.RunConfig) error {
 				return err
 			}
 			bootOpts := BootOptions{Cmd: config.Cmd}
-			err = ComposePackage(repo, sz, true, false, true, wd, pkg.Name, &bootOpts)
+			err = ComposePackage(repo, sz, true, false, true, wd, pkg.Name, &bootOpts, "zfs")
 			if err != nil {
 				return err
 			}

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -72,7 +72,7 @@ func OpenStackPush(c *cli.Context) error {
 
 	// Compose image locally.
 	fmt.Printf("Creating image of user-usable size %d MB.\n", sizeMB)
-	err = ComposePackage(repo, sizeMB, false, verbose, pullMissing, packageDir, appName, &bootOpts)
+	err = ComposePackage(repo, sizeMB, false, verbose, pullMissing, packageDir, appName, &bootOpts, "zfs")
 	if err != nil {
 		return err
 	}

--- a/util/rofs.go
+++ b/util/rofs.go
@@ -1,0 +1,384 @@
+/*
+ * Copyright (C) 2018 Waldemar Kozaczuk.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ *
+ * This code implements the machanics of creating a ROFS file system
+ * as described by comments in this Python code -
+ * https://raw.githubusercontent.com/cloudius-systems/osv/master/scripts/gen-rofs-img.py.
+ * The main public function used by upstream code is WriteRofsImage().
+ */
+
+package util
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	BLOCK_SIZE = 512
+
+	DIR_MODE  = 0x4000
+	REG_MODE  = 0x8000
+	LINK_MODE = 0xA000
+)
+
+type RofsSuperBlock struct {
+	Magic                    uint64
+	Version                  uint64
+	BlockSize                uint64
+	StructureInfoFirstBlock  uint64
+	StructureInfoBlocksCount uint64
+	DirectoryEntriesCount    uint64
+	SymlinksCount            uint64
+	InodesCount              uint64
+}
+
+type RofsDirectoryEntry struct {
+	InodeNumber uint64
+	Filename    string
+}
+
+type RofsSymlink struct {
+	Filename string
+}
+
+type RofsInode struct {
+	Mode        uint64
+	InodeNumber uint64
+	DataOffset  uint64
+	Count       uint64 // either file size in bytes or children count
+}
+
+type RofsFilesystem struct {
+	SuperBlock             RofsSuperBlock
+	DirectoryEntries       []*RofsDirectoryEntry
+	Symlinks               []*RofsSymlink
+	Inodes                 []*RofsInode
+	DirectoryEntriesByPath map[string][]string
+	CurrentBlock           int
+}
+
+func pad(buf *bytes.Buffer, count int) error {
+	for ; count > 0; count-- {
+		if err := buf.WriteByte(0); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeSuperBlock(imageFile *os.File, superBlock *RofsSuperBlock) error {
+	buf := bytes.Buffer{}
+	if err := binary.Write(&buf, binary.LittleEndian, superBlock); err != nil {
+		return err
+	}
+
+	if err := pad(&buf, BLOCK_SIZE-buf.Len()); err != nil {
+		return err
+	}
+
+	if _, err := imageFile.Seek(0, 0); err != nil {
+		return err
+	}
+
+	_, err := imageFile.Write(buf.Bytes())
+	return err
+}
+
+func ReadRofsSuperBlock(imageFile *os.File) (*RofsSuperBlock, error) {
+	if _, err := imageFile.Seek(0, 0); err != nil {
+		return nil, err
+	}
+
+	bytesArray := make([]byte, BLOCK_SIZE)
+	if _, err := imageFile.Read(bytesArray); err != nil {
+		return nil, err
+	}
+
+	superBlock := RofsSuperBlock{}
+	buffer := bytes.NewBuffer(bytesArray)
+	if err := binary.Read(buffer, binary.LittleEndian, &superBlock); err != nil {
+		return nil, err
+	}
+
+	return &superBlock, nil
+}
+
+func writeString(buffer *bytes.Buffer, str string) error {
+	if err := binary.Write(buffer, binary.LittleEndian, uint16(len(str))); err != nil {
+		return err
+	}
+	for _, character := range str {
+		if err := binary.Write(buffer, binary.LittleEndian, uint8(character)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeDirectoryEntry(imageFile *os.File, entry *RofsDirectoryEntry) (int, error) {
+	buf := bytes.Buffer{}
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(entry.InodeNumber)); err != nil {
+		return 0, err
+	}
+	if err := writeString(&buf, entry.Filename); err != nil {
+		return 0, err
+	}
+
+	return imageFile.Write(buf.Bytes())
+}
+
+func writeSymlink(imageFile *os.File, symlink *RofsSymlink) (int, error) {
+	buf := bytes.Buffer{}
+	if err := writeString(&buf, symlink.Filename); err != nil {
+		return 0, err
+	}
+
+	return imageFile.Write(buf.Bytes())
+}
+
+func writeInode(imageFile *os.File, inode *RofsInode) (int, error) {
+	buf := bytes.Buffer{}
+	if err := binary.Write(&buf, binary.LittleEndian, inode); err != nil {
+		return 0, err
+	}
+
+	return imageFile.Write(buf.Bytes())
+}
+
+func writeFile(filesystem *RofsFilesystem, imageFile *os.File, sourceFilePath string) (int, error) {
+	sourceFile, err := os.Open(sourceFilePath)
+	if err != nil {
+		return 0, err
+	}
+	defer sourceFile.Close()
+
+	buffer := make([]byte, BLOCK_SIZE)
+	totalCount := 0
+	for {
+		count, readError := sourceFile.Read(buffer)
+		if readError != nil && readError != io.EOF {
+			return 0, readError
+		}
+		totalCount += count
+		filesystem.CurrentBlock += 1
+		//
+		// Pad last block with 0 if EOF
+		if readError == io.EOF {
+			for ; count < BLOCK_SIZE; count++ {
+				buffer[count] = 0
+			}
+		}
+
+		if _, writeError := imageFile.Write(buffer); writeError != nil {
+			return 0, writeError
+		}
+		if readError == io.EOF {
+			break
+		}
+	}
+	err = imageFile.Sync()
+	return totalCount, err
+}
+
+func writeDirectory(filesystem *RofsFilesystem, imageFile *os.File, paths map[string]string,
+	sourceDirectoryPath string, verbose bool) (int, int, error) {
+
+	directoryEntries := filesystem.DirectoryEntriesByPath[sourceDirectoryPath]
+	sort.Strings(directoryEntries)
+
+	var thisDirectoryEntryInodes []*RofsDirectoryEntry
+	for _, directoryEntry := range directoryEntries {
+		//
+		// Add new inode
+		newInode := RofsInode{
+			InodeNumber: uint64(len(filesystem.Inodes) + 1),
+		}
+		filesystem.Inodes = append(filesystem.Inodes, &newInode)
+		//
+		// Add new directory entry
+		newDirectoryEntry := RofsDirectoryEntry{
+			InodeNumber: newInode.InodeNumber,
+			Filename:    directoryEntry,
+		}
+		thisDirectoryEntryInodes = append(thisDirectoryEntryInodes, &newDirectoryEntry)
+		//
+		// Check type of entry
+		directoryEntryPath := filepath.Join(sourceDirectoryPath, directoryEntry)
+		fi, err := os.Lstat(directoryEntryPath)
+		if err != nil {
+			return 0, 0, err
+		}
+
+		switch {
+		case fi.Mode()&os.ModeSymlink == os.ModeSymlink:
+			linkTarget, _ := os.Readlink(directoryEntryPath)
+			if strings.HasPrefix(linkTarget, "/") || strings.HasPrefix(linkTarget, "..") {
+				srcDir := filepath.Dir(directoryEntryPath)
+
+				if linkTarget, err = filepath.Abs(filepath.Join(srcDir, linkTarget)); err != nil {
+					return 0, 0, err
+				}
+				dst := paths[directoryEntryPath]
+				linkTarget = strings.TrimPrefix(linkTarget, strings.TrimSuffix(directoryEntryPath, dst))
+			}
+			if verbose {
+				fmt.Printf("Link %s to %s\n", paths[directoryEntryPath], linkTarget)
+			}
+			newInode.Mode = LINK_MODE
+			newInode.DataOffset = uint64(len(filesystem.Symlinks))
+			newInode.Count = uint64(1)
+			//
+			// Add new symlink entry
+			newSymlinkEntry := RofsSymlink{
+				Filename: linkTarget,
+			}
+			filesystem.Symlinks = append(filesystem.Symlinks, &newSymlinkEntry)
+
+		case fi.Mode().IsDir():
+			entriesCount, entriesIndex, err := writeDirectory(filesystem, imageFile, paths, directoryEntryPath, verbose)
+			if err != nil {
+				return 0, 0, err
+			}
+			newInode.Mode = DIR_MODE
+			newInode.DataOffset = uint64(entriesIndex)
+			newInode.Count = uint64(entriesCount)
+
+		case fi.Mode().IsRegular():
+			if verbose {
+				fmt.Printf("Adding file: %s\n", paths[directoryEntryPath])
+			}
+			newInode.DataOffset = uint64(filesystem.CurrentBlock)
+			bytesWritten, err := writeFile(filesystem, imageFile, directoryEntryPath)
+			if err != nil {
+				return 0, 0, err
+			}
+			newInode.Mode = REG_MODE
+			newInode.Count = uint64(bytesWritten)
+		}
+	}
+	thisDirectoryEntriesIndex := len(filesystem.DirectoryEntries)
+	filesystem.DirectoryEntries = append(filesystem.DirectoryEntries, thisDirectoryEntryInodes...)
+	return len(thisDirectoryEntryInodes), thisDirectoryEntriesIndex, nil
+}
+
+func writeFileSystem(filesystem *RofsFilesystem, imagePath string, paths map[string]string,
+	sourceRootPath string, verbose bool) error {
+
+	imageFile, err := os.Create(imagePath)
+	if err != nil {
+		return err
+	}
+	defer imageFile.Close()
+
+	if verbose {
+		fmt.Printf("Writing ROFS filesystem\n")
+	}
+	//
+	// Write super block
+	if err = writeSuperBlock(imageFile, &filesystem.SuperBlock); err != nil {
+		return err
+	}
+	//
+	// Create root inode
+	rootInode := RofsInode{
+		InodeNumber: uint64(len(filesystem.Inodes) + 1),
+		Mode:        DIR_MODE,
+	}
+	filesystem.Inodes = append(filesystem.Inodes, &rootInode)
+
+	entriesCount, entriesIndex, err := writeDirectory(filesystem, imageFile, paths, sourceRootPath, verbose)
+	if err != nil {
+		return err
+	}
+
+	systemStructureBlock := filesystem.CurrentBlock
+	rootInode.DataOffset = uint64(entriesIndex)
+	rootInode.Count = uint64(entriesCount)
+	//
+	// Write directory entries
+	bytesWritten := 0
+	for _, directoryEntry := range filesystem.DirectoryEntries {
+		count, err := writeDirectoryEntry(imageFile, directoryEntry)
+		if err != nil {
+			return err
+		}
+		bytesWritten += count
+	}
+	//
+	// Write symlinks
+	for _, symlink := range filesystem.Symlinks {
+		count, err := writeSymlink(imageFile, symlink)
+		if err != nil {
+			return err
+		}
+		bytesWritten += count
+	}
+
+	// Write inodes
+	for _, inode := range filesystem.Inodes {
+		count, err := writeInode(imageFile, inode)
+		if err != nil {
+			return err
+		}
+		bytesWritten += count
+	}
+
+	filesystem.SuperBlock.StructureInfoFirstBlock = uint64(systemStructureBlock)
+	filesystem.SuperBlock.StructureInfoBlocksCount = uint64(bytesWritten / BLOCK_SIZE)
+	if bytesWritten%BLOCK_SIZE > 0 {
+		filesystem.SuperBlock.StructureInfoBlocksCount++
+	}
+	filesystem.SuperBlock.DirectoryEntriesCount = uint64(len(filesystem.DirectoryEntries))
+	filesystem.SuperBlock.SymlinksCount = uint64(len(filesystem.Symlinks))
+	filesystem.SuperBlock.InodesCount = uint64(len(filesystem.Inodes))
+
+	if verbose {
+		sb := filesystem.SuperBlock
+		fmt.Printf("First block: %d, blocks count: %d\n", sb.StructureInfoFirstBlock, sb.StructureInfoBlocksCount)
+		fmt.Printf("Directory entries count %d\n", sb.DirectoryEntriesCount)
+		fmt.Printf("Symlinks count %d\n", sb.SymlinksCount)
+		fmt.Printf("Inodes count %d\n", sb.InodesCount)
+	}
+
+	return writeSuperBlock(imageFile, &filesystem.SuperBlock)
+}
+
+func WriteRofsImage(imagePath string, paths map[string]string, sourceRootPath string, verbose bool) error {
+	//
+	// Create main fileystem structure to keep track of all information about
+	// filesystem to be written to an image file
+	filesystem := RofsFilesystem{
+		SuperBlock: RofsSuperBlock{
+			Magic:     0xDEADBEAD,
+			Version:   1,
+			BlockSize: BLOCK_SIZE,
+		},
+		DirectoryEntries:       []*RofsDirectoryEntry{},
+		Symlinks:               []*RofsSymlink{},
+		Inodes:                 []*RofsInode{},
+		DirectoryEntriesByPath: make(map[string][]string),
+		CurrentBlock:           1,
+	}
+	//
+	// Create supporting map to allow to navigate directory entries
+	for src, dest := range paths {
+		if dest == "/" { // Skip root
+			continue
+		}
+		//
+		// Break src into directory path and basename and add to the DirectoryEntriesByPath
+		directory, filename := filepath.Dir(src), filepath.Base(src)
+		filesystem.DirectoryEntriesByPath[directory] = append(filesystem.DirectoryEntriesByPath[directory], filename)
+	}
+	return writeFileSystem(&filesystem, imagePath, paths, sourceRootPath, verbose)
+}

--- a/util/rofs_test.go
+++ b/util/rofs_test.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2018 Waldemar Kozaczuk.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package util_test
+
+import (
+	"github.com/mikelangelo-project/capstan/cmd"
+	"github.com/mikelangelo-project/capstan/util"
+	. "gopkg.in/check.v1"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type rofsSuite struct{}
+
+var _ = Suite(&rofsSuite{})
+
+func (*rofsSuite) TestWriteRofsImage(c *C) {
+	// We are going to create an empty temp directory.
+	tmp, _ := ioutil.TempDir("", "pkg")
+	defer os.RemoveAll(tmp)
+	//
+	// Copy test data to the temp dir so that we can create ROFS image out of it
+	err := copyDirectory("../cmd/testdata/hashing", tmp)
+
+	paths, err := cmd.CollectDirectoryContents(tmp)
+	c.Assert(err, IsNil)
+
+	rofsImagePath := path.Join(tmp, "rofs.img")
+	err = util.WriteRofsImage(rofsImagePath, paths, tmp, true)
+	c.Assert(err, IsNil)
+
+	rofsImage, err := os.OpenFile(rofsImagePath, os.O_RDONLY, 0644)
+	c.Assert(err, IsNil)
+	defer rofsImage.Close()
+
+	rofsSb, err := util.ReadRofsSuperBlock(rofsImage)
+	c.Assert(err, IsNil)
+	c.Assert(rofsSb.InodesCount, Equals, uint64(11))
+	c.Assert(rofsSb.DirectoryEntriesCount, Equals, uint64(10))
+	c.Assert(rofsSb.SymlinksCount, Equals, uint64(1))
+}
+
+func copyDirectory(srcDir string, dest string) error {
+	return filepath.Walk(srcDir, func(path string, info os.FileInfo, _ error) error {
+		relPath := strings.TrimPrefix(path, srcDir)
+		fi, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+
+		switch {
+		case fi.Mode()&os.ModeSymlink == os.ModeSymlink:
+			linkTarget, _ := os.Readlink(path)
+			if strings.HasPrefix(linkTarget, "/") || strings.HasPrefix(linkTarget, "..") {
+				srcDir := filepath.Dir(path)
+
+				if linkTarget, err = filepath.Abs(filepath.Join(srcDir, linkTarget)); err != nil {
+					return err
+				}
+				linkTarget = strings.TrimPrefix(linkTarget, strings.TrimSuffix(path, dest))
+			}
+			os.Symlink(linkTarget, filepath.Join(dest, relPath))
+
+		case fi.Mode().IsRegular():
+			from, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer from.Close()
+
+			destFile := filepath.Join(dest, relPath)
+			if err := os.MkdirAll(filepath.Dir(destFile), 0777); err != nil {
+				return err
+			}
+
+			to, err := os.OpenFile(destFile, os.O_RDWR|os.O_CREATE, 0666)
+			if err != nil {
+				return err
+			}
+			defer to.Close()
+
+			if _, err = io.Copy(to, from); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
These enclosed changes implement logic enhancing capstan to compose OSv images with ROFS filesystem as described by https://raw.githubusercontent.com/cloudius-systems/osv/master/scripts/gen-rofs-img.py.

The package compose command has new '-- fs' option allowing to specify filesystem - zfs or rofs. The zfs fileystem is default.

The example of building OSv image with ROFS:
capstan package compose java_example -fs rofs

It fixes #98.