### PR TITLE
Update unit tests to handle quoted timestamps

### DIFF
--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -117,7 +117,7 @@ func (s *suite) TestInitPackage(c *C) {
 				name: name
 				title: title
 				author: author
-				created: {TIMESTAMP}
+				created: "{TIMESTAMP}"
 			`,
 		},
 		{
@@ -133,7 +133,7 @@ func (s *suite) TestInitPackage(c *C) {
 				title: title
 				author: author
 				version: 1.2.3
-				created: {TIMESTAMP}
+				created: "{TIMESTAMP}"
 			`,
 		},
 		{
@@ -151,7 +151,7 @@ func (s *suite) TestInitPackage(c *C) {
 				require:
 				- demo1
 				- demo2
-				created: {TIMESTAMP}
+				created: "{TIMESTAMP}"
 			`,
 		},
 		{
@@ -166,7 +166,7 @@ func (s *suite) TestInitPackage(c *C) {
 				name: name
 				title: title
 				author: author
-				created: {TIMESTAMP}
+				created: "{TIMESTAMP}"
 			`,
 		},
 		{
@@ -181,7 +181,7 @@ func (s *suite) TestInitPackage(c *C) {
 				name: name
 				title: title
 				author: author
-				created: {TIMESTAMP}
+				created: "{TIMESTAMP}"
 				platform: Ubuntu-14.04
 			`,
 		},

--- a/core/yaml_test.go
+++ b/core/yaml_test.go
@@ -37,12 +37,12 @@ func (*yamlSuite) TestYamlTimeFieldMarshall(c *C) {
 		{
 			"simple",
 			"2017-09-14T18:08:16+02:00",
-			"created: 2017-09-14T18:08:16+02:00",
+			"created: \"2017-09-14T18:08:16+02:00\"",
 		},
 		{
 			"miliseconds should not get marshalled",
 			"2017-09-14T18:08:16.123456789+02:00",
-			"created: 2017-09-14T18:08:16+02:00",
+			"created: \"2017-09-14T18:08:16+02:00\"",
 		},
 		{
 			"empty",
@@ -80,7 +80,7 @@ func (*yamlSuite) TestYamlTimeFieldUnmarshall(c *C) {
 	}{
 		{
 			"RFC3339",
-			"created: 2017-09-14T18:08:16+02:00",
+			"created: \"2017-09-14T18:08:16+02:00\"",
 			"2017-09-14 18:08",
 		},
 		{


### PR DESCRIPTION
The yaml.v2 library apparently changed at some point to
start quoting string values when marshaling to YAML if their value
was found to be an RFC3339 timestamp.

This change makes package YAML files produced
by capstan to contain quoted 'created' field and break
some unit tests. 

To that extent this patch updates unit tests to handle both quoted and unquoted timestamps.

Signed-off-by: Waldemar Kozaczuk <jwkozaczuk@gmail.com>